### PR TITLE
docs: fixed typos + center alignment + config end punctuations

### DIFF
--- a/docs/client-objects/balloons.md
+++ b/docs/client-objects/balloons.md
@@ -12,13 +12,13 @@ Balloon timers can be customized by editing the `TimerGui` inside the balloon's 
 ## Configuration
 
 | Name | Default Value | Description
-|------|---------------|------------
-| `AllowJumpDismount` | true | Determines whether the balloon can be dismounted by jumping
-| `DestroyWhenExpired` | true | When true, balloons are automatically dismounted upon expiring, otherwise they lose their velocity and do not rise
-| `Force` | 5 | The velocity at which the balloon rises (or falls, if negative)
-| `KeepMomentum` | true | When true, objects will keep any momentum they had on the balloon after dismounting
+|:-----:|:-----:|:-----:
+| `AllowJumpDismount` | true | Determines whether the balloon can be dismounted by jumping.
+| `DestroyWhenExpired` | true | When true, balloons are automatically dismounted upon expiring, otherwise they lose their velocity and do not rise.
+| `Force` | 5 | The velocity at which the balloon rises (or falls, if negative).
+| `KeepMomentum` | true | When true, objects will keep any momentum they had on the balloon after dismounting.
 | `MaxHeight` | 0 | The maximum height difference between the balloon and the dispenser before expiring. Ignored if set to 0.
-| `RopeLength` | 8 | The length of the balloon's [rope][RopeConstraint]
-| `Timer` | 0 | The amount of time before the balloon expires automatically (infinite if set to 0)
+| `RopeLength` | 8 | The length of the balloon's [rope][RopeConstraint].
+| `Timer` | 0 | The amount of time before the balloon expires automatically (infinite if set to 0).
 
 [RopeConstraint]: https://create.roblox.com/docs/reference/engine/classes/RopeConstraint

--- a/docs/client-objects/boost-pads.md
+++ b/docs/client-objects/boost-pads.md
@@ -14,6 +14,6 @@ For the Type and Power settings, see [Boosters](boosters.md)
 
 | Name | Default Value | Description
 |:-----:|:-----:|:-----:
-| `Type` | Speed | The [type](boosters/#types) of the boost
-| `Power` | 32 (Speed), 100 (Jump) | The [power](boosters/#types) of the boost
-| `Distance` | 10 | How far above the boost pad the boost will be active, measured in studs
+| `Type` | Speed | The [type](boosters/#types) of the boost.
+| `Power` | 32 (Speed), 100 (Jump) | The [power](boosters/#types) of the boost.
+| `Distance` | 10 | How far above the boost pad the boost will be active, measured in studs.

--- a/docs/client-objects/conveyors.md
+++ b/docs/client-objects/conveyors.md
@@ -12,4 +12,4 @@ Conveyors are useful for quickly moving objects to different places. They can al
 
 | Name | Default Value | Description
 |:-----:|:-----:|:-----:
-| `Speed` | 10 | The speed the conveyor will move objects at, measured in studs per second
+| `Speed` | 10 | The speed the conveyor will move objects at, measured in studs per second.

--- a/docs/client-objects/damage-bricks.md
+++ b/docs/client-objects/damage-bricks.md
@@ -21,6 +21,6 @@ Damage Bricks are used to deal damage to the player, for example to punish the p
 
 | Name | Default Value | Description |
 |:-----:|:-----:|:-----: |
-| `Cooldown` | 1 | Time in seconds to wait before the Damage Brick can deal damage again |
+| `Cooldown` | 1 | Time in seconds to wait before the Damage Brick can deal damage again. |
 | `Type` | `kills` | The type of damage brick. See [the list of types.](#damage-brick-types) |
 | `Damage` | 0 | The amount of damage the player will take. The damage type must be set to `custom` for this to work. |

--- a/docs/client-objects/elevators.md
+++ b/docs/client-objects/elevators.md
@@ -11,7 +11,7 @@ Elevators can be used to move players and objects around, or launch them away. E
 | Name | Default Value | Description
 |:-----:|:-----:|:-----:
 | `ContinuousUpdates` | false | When true, the direction players and objects will be moved in will update when the Elevator moves. Otherwise, they will keep moving in the direction the Elevator was facing when they entered the Elevator.
-| `MaxForce` | Infinity | The maximum amount of force the Elevator can use when moving objects. Lower values will give the player more control over their movement while in the Elevator. Please note that the Elevator may not function if set to very low values (~2000 or lower)
-| `Speed` | 40 | The speed the Elevator will move objects at, in studs per second
+| `MaxForce` | Infinity | The maximum amount of force the Elevator can use when moving objects. Lower values will give the player more control over their movement while in the Elevator. Please note that the Elevator may not function if set to very low values (~2000 or lower).
+| `Speed` | 40 | The speed the Elevator will move objects at, in studs per second.
 | `HitboxMode` | `StaticWholeBody` | The [hitbox mode](/docs/misc.md#hitbox-modes) used by the Elevator.
-| `Vector` | `UpVector` | Which facing direction of the Elevator it will launch objects in. Supported values are `UpVector`, `RightVector` and `LookVector`. Use a negative `Speed` value if you want to reverse these directions
+| `Vector` | `UpVector` | Which facing direction of the Elevator it will launch objects in. Supported values are `UpVector`, `RightVector` and `LookVector`. Use a negative `Speed` value if you want to reverse these directions.

--- a/docs/client-objects/emitters.md
+++ b/docs/client-objects/emitters.md
@@ -15,4 +15,4 @@ Emitters can be used for cinematic effects and gameplay cues. They can be limite
 |:-----:|:-----:|:-----:
 | `GlobalSound` | true | Whether `Sound` instances should play globally or spatially from the Emitter.
 | `Uses` | 0 | How many times the Emitter can be used. Every time the emitter is used, this value is decremented. If set to 0, the Emitter will have infinite uses.
-| `Cooldown` | 1 | Time in seconds to wait before the Emitter can activate again
+| `Cooldown` | 1 | Time in seconds to wait before the Emitter can activate again.

--- a/docs/client-objects/jump-launchers.md
+++ b/docs/client-objects/jump-launchers.md
@@ -13,5 +13,5 @@ Jump Launchers are most commonly used as double jumps. They can be buffered by h
 
 | Name | Default Value | Description
 |:-----:|:-----:|:-----:
-| `Cooldown` | 0.25 | Time in seconds to wait before the Jump Launcher can activate again
-| `Force` | 60 | The speed interacting objects will be launched at when activated
+| `Cooldown` | 0.25 | Time in seconds to wait before the Jump Launcher can activate again.
+| `Force` | 60 | The speed interacting objects will be launched at when activated.

--- a/docs/client-objects/keys.md
+++ b/docs/client-objects/keys.md
@@ -30,4 +30,4 @@ Any parts named `ReturnKey` inside of the key group will cause the key to return
 
 | Name | Default Value | Description
 |:-----:|:-----:|:-----:
-| `RequiredKeys` | 1 | The amount of keys needed to open the door
+| `RequiredKeys` | 1 | The amount of keys needed to open the door.

--- a/docs/client-objects/lighting-changers.md
+++ b/docs/client-objects/lighting-changers.md
@@ -62,11 +62,11 @@ the Lighting service, can be specified as the object to change:
 |:-----:|:-----:|:-----:
 | `Lighting` | Ambient, Brightness, ClockTime, ColorShift_Bottom, ColorShift_Top, EnvironmentDiffuseScale, EnvironmentSpecularScale, ExposureCompensation, FogColor, FogEnd, FogStart, GeographicLatitude, GlobalShadows,  OutdoorAmbient, ShadowSoftness, TimeOfDay | When an `Atmosphere` object is used, fog will automatically be disabled and have no effect.
 | `Atmosphere` | Enabled, Density, Offset, Color, Decay, Glare, Haze | Because `Atmosphere` objects do not have an `Enabled` property, it instead toggles whether the Atmosphere effect is parented to `Lighting`.
-| `BlurEffect` | Size
-| `BloomEffect` | Intensity, Size, Threshold
-| `ColorCorrectionEffect` | Brightness, Contrast, Saturation, TintColor
-| `DepthOfFieldEffect` | FarIntensity, FocusDistance, InFocusRadius, NearIntensity
-| `Sky` | MoonAngularSize, MoonTextureId, SkyboxBk, SkyboxDn, SkyboxFt, SkyboxLf, SkyboxRt, SkyboxUp, StarCount, SunAngularSize, SunTextureId, SkyboxOrientation
+| `BlurEffect` | Size.
+| `BloomEffect` | Intensity, Size, Threshold.
+| `ColorCorrectionEffect` | Brightness, Contrast, Saturation, TintColor.
+| `DepthOfFieldEffect` | FarIntensity, FocusDistance, InFocusRadius, NearIntensity.
+| `Sky` | MoonAngularSize, MoonTextureId, SkyboxBk, SkyboxDn, SkyboxFt, SkyboxLf, SkyboxRt, SkyboxUp, StarCount, SunAngularSize, SunTextureId, SkyboxOrientation.
 
 ### Properties
 

--- a/docs/client-objects/morphers.md
+++ b/docs/client-objects/morphers.md
@@ -7,7 +7,7 @@ Morphers are objects that can spawn and move parts.
 Morphers can be used to spawn parts the player can interact with.
 If the Morpher has only one NewMorph part, the main Morph part will move to that part's position rather than creating clones. You can weld parts to the main Morph part and use this functionality to create complex mechanics such as moving objects in cutscenes.
 
-The Morpher's sounds can be modifiedd by changing them inside each Morpher button's configuration.
+The Morpher's sounds can be modified by changing them inside each Morpher button's configuration.
 
 ## Configuration
 

--- a/docs/client-objects/music-zone-editors.md
+++ b/docs/client-objects/music-zone-editors.md
@@ -10,7 +10,7 @@ Music Zone Editors can change the priority of a Music Zone as well as any proper
 
 | Name | Default Value | Description
 |:-----:|:-----:|:-----:
-| `Cooldown` | 1 | Time in seconds to wait before the Music Zone Editor can activate again
+| `Cooldown` | 1 | Time in seconds to wait before the Music Zone Editor can activate again.
 | `OneTimeUse` | false | When true, the music zone editor can only be used one time.
 | `ZoneName` | `Floor1` | The name of the music zone to edit. For organization purposes, it is highly recommended to have your music zones' names start with the name of your tower.
 

--- a/docs/client-objects/seats.md
+++ b/docs/client-objects/seats.md
@@ -14,4 +14,4 @@ Keep in mind that the player might interact oddly with other client objects whil
 
 | Name | Default Value | Description
 |:-----:|:-----:|:-----:
-| `Cooldown` | 1 | The time it takes the Seat to be mountable again after dismounting
+| `Cooldown` | 1 | The time it takes the Seat to be mountable again after dismounting.

--- a/docs/client-objects/sequencers.md
+++ b/docs/client-objects/sequencers.md
@@ -78,12 +78,12 @@ Sequencers can be synced to the tower's music. This will adjust the speed of the
 
 | Name | Default Value | Description |
 |:-----:|:-----:|:-----:|
-| `Cooldown` | 0 | The amount of time it will take for the Sequencer to be usable again after it finishes |
+| `Cooldown` | 0 | The amount of time it will take for the Sequencer to be usable again after it finishes. |
 | `LoopAmount` | 0 | The amount of times the Sequencer will run when activated. If set to 0, it will only run once. If set to any negative number, it will keep running forever. |
 | `LoopDelay` | 0 | The amount of time the Sequencer will wait before reactivating after every loop. |
 | `RunAtStart` | false | When true, the Sequencer will automatically run when it loads, without it having to be activated by touch. |
-| `Speed` | 1 | The speed the Sequencer will move at, in studs per second |
-| `Visualize` | true | When true, the Sequencer will move to show it's progress, and color itself to show it's current state. Useful for debugging sequences. |
+| `Speed` | 1 | The speed the Sequencer will move at, in studs per second. |
+| `Visualize` | true | When true, the Sequencer will move to show its progress, and color itself to show its current state. Useful for debugging sequences. |
 
 [Tag]: https://create.roblox.com/docs/studio/properties#instance-tags
 [Sequence Pointers]: #sequence-pointers

--- a/docs/client-objects/teleporters.md
+++ b/docs/client-objects/teleporters.md
@@ -11,7 +11,7 @@ Teleporters can be used to move players and parts to a designated position.
 | Name | Default Value | Description
 |:-----:|:-----:|:-----:
 | `DisableCollision` | false | Only applies to players. If true, the player will not activate objects they interact with while teleporting.
-| `Instant` | true | If true, the teleported object will be instantly moved to the destination. Otherwise, they will move to the destination using the provided [TweenConfiguration](/docs/global-configurations/tween-configurations.md)
+| `Instant` | true | If true, the teleported object will be instantly moved to the destination. Otherwise, they will move to the destination using the provided [TweenConfiguration](/docs/global-configurations/tween-configurations.md).
 | `KeepVelocity` | true | If true, the teleported object will retain its previous velocity when teleporting. Otherwise, it will be reset to 0.
 | `Offset` | [`CFrame.new(0, 4, 0)`](https://create.roblox.com/docs/reference/engine/datatypes/CFrame) | When being teleported, the location the teleported object will teleport to will be offset by this value.
 | `SeamlessTeleport` | false | If true, the teleported object will be moved and rotated so that it ends up in the same position and orientation relative to the destination as it was relative to the teleporter. Additionally, if a character is being teleported, the player's camera will be oriented relative to the player's new world orientation. Overrides `Offset`.

--- a/docs/client-objects/turrets.md
+++ b/docs/client-objects/turrets.md
@@ -16,7 +16,7 @@ Turrets can be used to shoot projectiles the player has to avoid, or to shoot ou
 | `FireRate` | 1 | The amount of bullets that will be shot per second.
 | `MaxLifetime` | 5 | The maximum amount of time in seconds that bullets should exist for. Bullets will automatically despawn after this time if they haven't already been destroyed.
 | `Range` | 50 | The turret's maximum activation range, measured in studs. If the player is further away than this value, the turret will not fire.
-| `Speed` | 50 | The speed that fired bullets will move at, measured in studs per second
+| `Speed` | 50 | The speed that fired bullets will move at, measured in studs per second.
 
 ## Activator Parts
 

--- a/docs/client-objects/vanishers.md
+++ b/docs/client-objects/vanishers.md
@@ -22,10 +22,10 @@ Each `VanishMode` has unique logic.
 
 | Name | Default Value | Description
 |:-----:|:-----:|:-----:
-| `BlinkCount` | 3 | Amount of blinks in `Blink` mode
-| `ConstantNoRecovery` | false | Prevents recovery in `Constant` mode when not in contact
-| `Invert` | false | Reverses behavior: visible becomes invisible and vice versa
-| `RespawnFade` | false | Whether the part fades in when respawning
-| `RespawnTime` | 2 | Seconds before the part reappears
-| `ShrinkDirection` | `Center` | [Direction of shrinking](#vanish-modes)
-| `VanishMode` | `Fade` | [Vanish behavior](#vanish-modes)
+| `BlinkCount` | 3 | Amount of blinks in `Blink` mode.
+| `ConstantNoRecovery` | false | Prevents recovery in `Constant` mode when not in contact.
+| `Invert` | false | Reverses behavior: visible becomes invisible and vice versa.
+| `RespawnFade` | false | Whether the part fades in when respawning.
+| `RespawnTime` | 2 | Seconds before the part reappears.
+| `ShrinkDirection` | `Center` | [Direction of shrinking](#vanish-modes).
+| `VanishMode` | `Fade` | [Vanish behavior](#vanish-modes).

--- a/docs/client-objects/vines.md
+++ b/docs/client-objects/vines.md
@@ -1,19 +1,19 @@
 # Vines
 
-Vines are objects that attach the player or a pushbox to a part using the provided constraint ([RopeConstraint](https://create.roblox.com/docs/reference/engine/classes/RopeConstraint) by default). The used constraint can be modified by inserting a new constraint named `VineConstraint` to the Vine.
-Objects on vines dismount either when touching a [Dismounter](dismounters.md) or when the player jumps.
+Vines are objects that attach the player or a Pushbox to a part using the provided constraint ([RopeConstraint](https://create.roblox.com/docs/reference/engine/classes/RopeConstraint) by default). The used constraint can be modified by inserting a new constraint named `VineConstraint` to the Vine.
+Objects on Vines dismount either when touching a [Dismounter](dismounters.md) or when the player jumps.
 
 The Vine's sounds can be changed by modifying the `Sound` objects inside the `Sounds` folder.
 
 ## Use Cases
 
 Vines are used in gameplay, for example to swing to platforms that are otherwise impossible to reach. They can be combined with fast elevators to make unique momentum jumps.
-The length of the vine can be adjusted by editing the length of the constraint.
+The length of the Vine can be adjusted by editing the length of the constraint.
 
 ## Configuration
 
 | Name | Default Value | Description
-|------|---------------|------------
-| `AllowJumpDismount` | true | Determines whether the vine can be dismounted by jumping
-| `KeepMomentum` | true | When true, objects will retain their momentum upon grabbing the vine
-| `RespawnTime` | 1 | The time it takes for the vine's `AttachmentPart` to re-appear after the player dismounts it
+|:-----:|:-----:|:-----:
+| `AllowJumpDismount` | true | Determines whether the Vine can be dismounted by jumping.
+| `KeepMomentum` | true | When true, objects will retain their momentum upon grabbing the Vine.
+| `RespawnTime` | 1 | The time it takes for the Vine's `AttachmentPart` to re-appear after the player dismounts it.

--- a/docs/client-objects/ziplines.md
+++ b/docs/client-objects/ziplines.md
@@ -4,23 +4,23 @@ Ziplines carry attached objects along a set path.
 
 ## Use Cases
 
-Ziplines can be used to transport players or pushboxes along a set path. They will always try to keep attached objects upright.
+Ziplines can be used to transport players or Pushboxes along a set path. They will always try to keep attached objects upright.
 
 ## Configuration
 
-A zipline's route is determined using [De Casteljou's algorithm](https://en.wikipedia.org/wiki/De_Casteljau%27s_algorithm) on all points in the `Points` folder. These must be named in a numbered sequence (eg. `1`, `2`, `3`). Any other parts in the folder are ignored. All points are automatically welded to the `MountPart`.
+A Zipline's route is determined using [De Casteljou's algorithm](https://en.wikipedia.org/wiki/De_Casteljau%27s_algorithm) on all points in the `Points` folder. These must be named in a numbered sequence (eg. `1`, `2`, `3`). Any other parts in the folder are ignored. All points are automatically welded to the `MountPart`.
 
-The zipline's particles and sounds can be adjusted by adding particles to the `GuideEffects` folder and editing the `Sound` objects in the `Sounds` folder. Defaults will be used if these folders are not present.
+The Zipline's particles and sounds can be adjusted by adding particles to the `GuideEffects` folder and editing the `Sound` objects in the `Sounds` folder. Defaults will be used if these folders are not present.
 
-Please note that any configuration related to player input will also apply when non-player objects are mounted on the zipline.
+Please note that any configuration related to player input will also apply when non-player objects are mounted on the Zipline.
 
 | Name | Default Value | Description
 |:-----:|:-----:|:-----:
-|`AllowEndDismount` | `true` | When true, the attached object will automatically detach from the zipline when it reaches the end
-|`AllowJumpDismount` | `true` | When true, jumping will cause the attached object to dismount from the zipline
-|`AllowUserControl` | `false` | When true, moving forwards or backwards will allow the attached object to move themselves along the zipline. When changing directions, the attached object will accelerate and deccelerate at 4 studs per second squared up to the maximum speed.
-|`GuideColor` | `(255, 255, 0)` | The color of the part that connects the zipline to the attached object
-|`KeepMomentum` | `false` | Whether the attached object retains its momentum when dismounted. Note that if a player has negative vertical momentum, it will not be retained because the player performs a jump when dismounting
-|`RopeLength`| 5 | The length of the rope formed between the attached object and the guide part
+|`AllowEndDismount` | `true` | When true, the attached object will automatically detach from the Zipline when it reaches the end.
+|`AllowJumpDismount` | `true` | When true, jumping will cause the attached object to dismount from the Zipline.
+|`AllowUserControl` | `false` | When true, moving forwards or backwards will allow the attached object to move themselves along the Zipline. When changing directions, the attached object will accelerate and deccelerate at 4 studs per second squared up to the maximum speed.
+|`GuideColor` | `(255, 255, 0)` | The color of the part that connects the Zipline to the attached object.
+|`KeepMomentum` | `false` | Whether the attached object retains its momentum when dismounted. Note that if a player has negative vertical momentum, it will not be retained because the player performs a jump when dismounting.
+|`RopeLength`| 5 | The length of the rope formed between the attached object and the guide part.
 |`Segments`| 20 | The amount of segments the curve is formed by. Please note that there is a limit of 100 segments in order to reduce lag.
-|`Speed` | 5 | The speed the guide part travels at, in studs per second
+|`Speed` | 5 | The speed the guide part travels at, in studs per second.


### PR DESCRIPTION
Fixed typos & a couple of casing issues,
fixed table alignment for vines and balloons,
added end punctuations to configuration notes for consistency.

Resolves issue #40.