### PR TITLE
Update dialog-system.md (fixing misspelled attribute)

### DIFF
--- a/docs/client-objects/dialog-system.md
+++ b/docs/client-objects/dialog-system.md
@@ -31,7 +31,7 @@ Each dialog object has attributes that control how the text displays, and also c
 | Name | Default Value | Description
 |:-----:|:-----:|:-----:
 | `ActivateButtonBeforeDialog` | N/A (Color3 Attribute) | Activates any button (before the dialog plays) that is the same color as the attribute.
-| `ActivateButtonTag` | N/A (string) | Activates any button (before the dialog plays) that has a Tag matching the attribute.
+| `ActivateButtonTagBeforeDialog` | N/A (string) | Activates any button (before the dialog plays) that has a Tag matching the attribute.
 | `ActivateButton` | N/A (Color3 Attribute) | Activates any button that is the same color as the attribute.
 | `ActivateButtonTag` | N/A (string) | Activates any button that has a Tag matching the attribute.
 | `AwaitFinish` | true | Determines whether the dialog will wait for the text to finish typing.


### PR DESCRIPTION
properly named ActivateButtonTagBeforeDialog attribute