### PR TITLE
Resolve various type errors with New Type Solver

### DIFF
--- a/Kit/Managers/CharacterManager/PhysicsFixer.local.luau
+++ b/Kit/Managers/CharacterManager/PhysicsFixer.local.luau
@@ -19,11 +19,10 @@ Thank you
 local Players = game:GetService("Players")
 local RunService = game:GetService("RunService")
 
-local character = Players.LocalPlayer.Character or Players.LocalPlayer.CharacterAdded:Wait()
-local humanoid: Humanoid? = character:WaitForChild("Humanoid")
-if not humanoid then
-	return
-end
+local localPlayer = Players.LocalPlayer :: Player
+
+local character = localPlayer.Character or localPlayer.CharacterAdded:Wait()
+local humanoid = character:WaitForChild("Humanoid") :: Humanoid
 
 -- Head collision glitch fix
 local head = character:FindFirstChild("Head")
@@ -34,7 +33,7 @@ if head and head:IsA("BasePart") then
 end
 
 -- Truss Fix
--- Original script by AkaWhats (& some help by MasSpartan)
+-- Original script by AkaWhats (& some help by Nullspace)
 -- Code touchups & some micro-optimizations done by synnwave
 
 local DEFAULT_FPS = 1 / 60
@@ -55,8 +54,8 @@ local STATES = {
     [Enum.HumanoidStateType.Running] = false,
 }
 
-local fps
-local function onStateChanged(oldState, newState)
+local fps: number
+local function onStateChanged(oldState: Enum.HumanoidStateType, newState: Enum.HumanoidStateType)
     if newState ~= oldState and STATES[newState] then
         for state, allowed in STATES do
             if allowed and state ~= newState then

--- a/Kit/Managers/CharacterManager/TypeDefs.luau
+++ b/Kit/Managers/CharacterManager/TypeDefs.luau
@@ -104,7 +104,7 @@ export type CharacterManager = {
 	ValidateDamageBrick: (self: CharacterManager, brick: BasePart) -> (number | string)?,
 
 	-- helper functions
-	GetHumanoid: (self: CharacterManager, player: Player) -> Humanoid?,
+	GetHumanoid: (self: CharacterManager, player: Player?) -> Humanoid?,
 	ChangeHumanoidProperty: (self: CharacterManager, property: string, value: any, tweenInfo: TweenInfo?) -> (),
 
 	-- booster functions

--- a/Kit/Managers/CharacterManager/TypeDefs.luau
+++ b/Kit/Managers/CharacterManager/TypeDefs.luau
@@ -17,8 +17,6 @@ Thank you
 
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local GuiManager = ReplicatedStorage.Framework.Kit.Managers.GuiManager
-
 export type __VALID_DAMAGEBRICKS = {
 	kills: number,
 	double: number,
@@ -72,7 +70,7 @@ export type BoostData = {
 	power: number,
 	
 	priority: number?,
-	frame: typeof(GuiManager.BoostFrame)?, -- created later
+	frame: typeof(ReplicatedStorage.Framework.Kit.Managers.GuiManager.BoostFrame)?, -- created later
 	module: Boost,
 	extraVariables: {[string]: any},
 
@@ -101,10 +99,10 @@ export type CharacterManager = {
 
 	-- damage functions
 	Damage: (self: CharacterManager, damage: BasePart | number | string) -> (),
-	ValidateDamageBrick: (self: CharacterManager, brick: BasePart) -> (number | string)?,
+	ValidateDamageBrick: (self: CharacterManager, brick: BasePart) -> ((number | string)?, number?),
 
 	-- helper functions
-	GetHumanoid: (self: CharacterManager, player: Player?) -> Humanoid?,
+	GetHumanoid: (self: CharacterManager, player: Player) -> Humanoid?,
 	ChangeHumanoidProperty: (self: CharacterManager, property: string, value: any, tweenInfo: TweenInfo?) -> (),
 
 	-- booster functions

--- a/Kit/Managers/CharacterManager/init.luau
+++ b/Kit/Managers/CharacterManager/init.luau
@@ -117,7 +117,7 @@ Functions
 function CharacterManager:ValidateDamageBrick(brick: BasePart)
 	local damageAmount: (number | string)?
 	if brick:GetAttribute("Activated") == false then
-		return
+		return nil, nil
 	end
 
 	local configuration = brick:FindFirstChild("DamageBrickConfiguration")
@@ -151,7 +151,7 @@ function CharacterManager:Damage(damage: BasePart | string | number)
 		return
 	end
 
-	local cooldown = 0
+	local cooldown: number
 	local damageAmount: (number | string)?
 	if typeof(damage) == "Instance" and damage:IsA("BasePart") then
 		damageAmount, cooldown = CharacterManager:ValidateDamageBrick(damage)
@@ -162,7 +162,7 @@ function CharacterManager:Damage(damage: BasePart | string | number)
 	if not damageAmount then
 		return
 	end
-	if cooldown > 0 and typeof(damage) == "Instance" then
+	if (cooldown or 0) > 0 and typeof(damage) == "Instance" then
 		damageCooldown[damage] = true
 		task.delay(cooldown, function()
 			damageCooldown[damage] = false
@@ -177,11 +177,7 @@ end
 	
 	Returns the `player`'s `Humanoid` if it exists.
 ]=]
-function CharacterManager:GetHumanoid(player: Player?): Humanoid?
-	if not player then
-		return nil
-	end
-	
+function CharacterManager:GetHumanoid(player: Player): Humanoid?
 	local character = player.Character
 	if not character then
 		return nil
@@ -197,7 +193,7 @@ end
 	A `TweenInfo` can be provided to tween the value.
 ]=]
 function CharacterManager:ChangeHumanoidProperty(property: string, value: any, tweenInfo: TweenInfo?)
-	local humanoid = CharacterManager:GetHumanoid(Players.LocalPlayer)
+	local humanoid = CharacterManager:GetHumanoid(Players.LocalPlayer :: Player)
 	if not humanoid then
 		return
 	end
@@ -330,7 +326,7 @@ function CharacterManager:StartBoost(boostData: _TDefs.BoostData)
 	if boostData.mode == "Default" then --handle regular boosters
 		boostData.infinite = CharacterManager:IsBoostInfinite(boostData)
 
-		local boostLoop
+		local boostLoop: RBXScriptConnection
 		boostLoop = RunService.Heartbeat:Connect(function()
 			local activeBoostData = CharacterManager:GetActiveBoost(boostData.type, boostData.mode)
 

--- a/Kit/Managers/CharacterManager/init.luau
+++ b/Kit/Managers/CharacterManager/init.luau
@@ -177,10 +177,14 @@ end
 	
 	Returns the `player`'s `Humanoid` if it exists.
 ]=]
-function CharacterManager:GetHumanoid(player: Player): Humanoid?
+function CharacterManager:GetHumanoid(player: Player?): Humanoid?
+	if not player then
+		return nil
+	end
+	
 	local character = player.Character
 	if not character then
-		return
+		return nil
 	end
 
 	return character:FindFirstChildOfClass("Humanoid")

--- a/Kit/Managers/ClientObjectManager/init.luau
+++ b/Kit/Managers/ClientObjectManager/init.luau
@@ -60,11 +60,11 @@ local function traverseFolders(folder: Instance, repository: Repo, startingPath:
 				continue
 			end
 
-			local cached = requireCache[instance]
+			local cached: (ScopeTypes.LegacyRepositoryModule | ScopeTypes.RepositoryModule)? = requireCache[instance]
 			if not requireCache[instance] then
 				-- requires already cache but i think it'l be a bit more
 				-- performant doing this
-				local loadSuccess, loadReturns = pcall(require, instance)
+				local loadSuccess, loadReturns: (ScopeTypes.LegacyRepositoryModule | ScopeTypes.RepositoryModule)? = pcall(require, instance)
 				if not loadSuccess then
 					Log({
 						`Failed to load repository script "{path}"`,
@@ -278,7 +278,7 @@ function ClientObjectManager:Init()
 		local property = if i == 2 then "LocalTransparencyModifier" else "Transparency"
 		for _, instance in CollectionService:GetTagged(tag) do
 			if instance:IsA("BasePart") then
-				instance[property] = 1
+				(instance :: any)[property] = 1
 			end
 		end
 

--- a/Kit/Managers/FlipManager/init.luau
+++ b/Kit/Managers/FlipManager/init.luau
@@ -71,7 +71,7 @@ Functions
 ---------------------------------------------------------------------------
 ]]
 
-local localPlayer = Players.LocalPlayer
+local localPlayer = Players.LocalPlayer :: Player
 
 local flipCooldowns = {}
 
@@ -100,7 +100,7 @@ function FlipManager:TryFlip()
 		return
 	end
 
-	for _, touchingPart: BasePart in Workspace:GetPartsInPart(torso, PARAMS) do
+	for _, touchingPart in Workspace:GetPartsInPart(torso, PARAMS) do
 		if
 			(
 				not touchingPart:HasTag("CanFlip")
@@ -118,16 +118,16 @@ function FlipManager:TryFlip()
 			flipCooldowns[touchingPart] = nil
 		end)
 
-		local teleportPart = touchingPart
+		local teleportPart: BasePart = touchingPart
 		if not touchingPart:HasTag("DoNotFlipPlayer") then
 			local teleportToObject = touchingPart:FindFirstChild("TeleToObject")
 			if
 				teleportToObject
 				and teleportToObject:IsA("ObjectValue")
 				and teleportToObject.Value
-				and teleportToObject.Value:IsA("BasePart")
+				and (teleportToObject.Value :: Instance):IsA("BasePart")
 			then
-				teleportPart = teleportToObject.Value
+				teleportPart = teleportToObject.Value :: BasePart
 			elseif teleportToObject then
 				warn("blank", teleportToObject, "value")
 				return
@@ -174,7 +174,7 @@ function FlipManager:BindToFlip(part: BasePart, callback: (rootPart: BasePart) -
 	end
 
 	local callbacks = FlipManager.__callbacks
-	local callbackID = HttpService:GenerateGUID()
+	local callbackID: string? = HttpService:GenerateGUID()
 	if not callbacks[part] then
 		callbacks[part] = {}
 	end

--- a/Kit/Managers/GuiManager/init.luau
+++ b/Kit/Managers/GuiManager/init.luau
@@ -45,6 +45,8 @@ local Log = require(Framework.Log)
 local CharacterManager_Types = require(Kit.Managers.CharacterManager.TypeDefs)
 local KitSettings = require(ReplicatedStorage.KitSettings)
 
+local localPlayer = Players.LocalPlayer :: Player
+
 --[[
 ---------------------------------------------------------------------------
 Main table
@@ -88,9 +90,9 @@ end
 	
 	Creates and returns a boost timer frame for the given `boostType`.
 ]=]
-function GuiManager:CreateBoostFrame(boostData: CharacterManager_Types.BoostData): _TDefs.BoostTimerFrame
+function GuiManager:CreateBoostFrame(boostData: CharacterManager_Types.BoostData): _TDefs.BoostTimerFrame?
 	if boostData.hideGUI then
-		return -- don't make one if they disabled it
+		return nil-- don't make one if they disabled it
 	end
 
 	boostID += 1
@@ -116,7 +118,7 @@ function GuiManager:CreateBoostFrame(boostData: CharacterManager_Types.BoostData
 	frame.LayoutOrder = -boostID
 	frame.Parent = GuiManager.Gui.Boosts
 
-	boostData.frame = frame
+	boostData.frame = frame :: _TDefs.BoostTimerFrame?
 	TweenService:Create(frame, BOOST_FRAME_TWEEN_INFO, { Size = script.BoostFrame.Size }):Play()
 
 	GuiManager:UpdateBoostFrame(boostData)
@@ -216,7 +218,7 @@ function GuiManager:__updateKeyDisplay()
 	end
 
 	local characterCFrame
-	local character = Players.LocalPlayer.Character
+	local character = (Players.LocalPlayer :: Player).Character
 	if character then
 		characterCFrame = character:GetPivot()
 	end
@@ -295,24 +297,22 @@ end
 ]=]
 function GuiManager:DisplayGUI(guiName: string, ...: any)
 	local gui = script:FindFirstChild(guiName)
-	if not gui then -- already being displayed?
+	if not gui or not gui:IsA("ScreenGui") then -- already being displayed?
 		Log({
 			`{guiName} GUI not found or already visible!!`,
 			type = "warn",
 		})
-
-		return true
+		return
 	end
 
 	if guiName == "debug" then
 		local displayMemory = ...
-		gui.memory.Visible = displayMemory
-		gui.memory.LocalScript.Enabled = displayMemory
+		(gui :: typeof(script.debug)).memory.Visible = displayMemory
+		do (gui :: typeof(script.debug)).memory.LocalScript.Enabled = displayMemory end
 	end
 
 	gui.Enabled = true
 	gui.Parent = GuiManager.PlayerGui
-	return true
 end
 
 function GuiManager:Init()
@@ -321,17 +321,16 @@ function GuiManager:Init()
 	end
 	self.__initialized = true
 
-	local localPlayer = Players.LocalPlayer
-	local playerGui = localPlayer:WaitForChild("PlayerGui")
+	local playerGui = localPlayer:WaitForChild("PlayerGui") :: PlayerGui
 	task.spawn(function()
-		GuiManager.Gui = playerGui:WaitForChild("EffectGUI", 5)
+		GuiManager.Gui = playerGui:WaitForChild("EffectGUI", 5) :: index<_TDefs.GuiManager, "Gui">
 	end)
 	GuiManager.PlayerGui = playerGui
 
 	--> Detect any new EffectGUIs
 	playerGui.ChildAdded:Connect(function(child)
 		if child.Name == "EffectGUI" then
-			GuiManager.Gui = child
+			GuiManager.Gui = child :: index<_TDefs.GuiManager, "Gui">
 		end
 	end)
 

--- a/Kit/Managers/ScopeConstructor/TypeDefs.luau
+++ b/Kit/Managers/ScopeConstructor/TypeDefs.luau
@@ -54,7 +54,7 @@ export type ScopeCommunicator = typeof(setmetatable({} :: __Communicator_params,
 -----------------------------------------
 --> Scope Types
 
-export type RepositoryModule = { Run: (scope: Scope, repository: any) -> (), [string]: any }
+export type RepositoryModule = { Run: (scope: Scope, repository: any) -> (), Init: ((utility: any) -> ())?, [string]: any }
 export type LegacyRepositoryModule = (scope: Scope, repository: any) -> ()
 
 export type __Scope_params = {

--- a/Kit/Repository/Interactables/BoostRemover/init.luau
+++ b/Kit/Repository/Interactables/BoostRemover/init.luau
@@ -29,14 +29,10 @@ local BoostRemover = {
 	RunOnStart = false,
 }
 
-local REMOVER_CONFIG_TEMPLATE
-function BoostRemover.Init(utility: _T.Utility)
-	local Config = utility.Config
-	REMOVER_CONFIG_TEMPLATE = {
-		Type = "Unknown",
-		Mode = "",
-	}
-end
+local REMOVER_CONFIG_TEMPLATE = {
+	Type = "Unknown",
+	Mode = "",
+}
 
 local SequencerSupport = require(script.SequencerSupport)
 local function setupCache(rootScope: _T.Scope, utility: _T.Utility)

--- a/Kit/Repository/Interactables/Booster/init.luau
+++ b/Kit/Repository/Interactables/Booster/init.luau
@@ -28,19 +28,19 @@ local _T = require(ReplicatedStorage.Framework.ClientTypes)
 local CharacterManager_Types = require(ReplicatedStorage.Framework.Kit.Managers.CharacterManager.TypeDefs)
 local SequencerSupport = require(script.SequencerSupport)
 
-type Booster = {
+type Booster<T> = {
 	hitbox: BasePart,
 	configuration: { [string]: any },
 	extraVariables: { [string]: any},
-	startTweenConfig: { [string]: any },
-	endTweenConfig: { [string]: any },
+	startTweenConfig: T,
+	endTweenConfig: T,
 	id: string,
 }
 
-type BoosterCache = {
+type BoosterCache<T> = {
 	activators: { [BasePart]: () -> () },
-	boosters: { Booster },
-	activeBoosters: { [string]: Booster? },
+	boosters: { Booster<T> },
+	activeBoosters: { [string]: Booster<T> },
 }
 
 local Booster = {
@@ -93,7 +93,7 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 		else {}
 
 	--> Functions
-	local function getBoostData(booster: Booster): CharacterManager_Types.BoostData?
+	local function getBoostData(booster: Booster<typeof(Config.TWEEN_CONFIG)>): CharacterManager_Types.BoostData?
 		local boostModule = CharacterUtil.getBoostModule(booster.configuration.Type)
 		if not boostModule then
 			return nil
@@ -137,7 +137,7 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 	CharacterUtil.getHitbox("StaticWholeBody", overlapParams)
 
 	local cache = utility.Scope.getCached(scope, scope.scriptPath, function()
-		local cache: BoosterCache = {
+		local cache: BoosterCache<typeof(Config.TWEEN_CONFIG)> = {
 			activators = {},
 			boosters = {},
 			activeBoosters = {},
@@ -161,7 +161,7 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 			lastTick = currentTick
 
 			--> Get touching parts and determine if any zone boosters are being touched
-			local touchingBoosters: { Booster } = {}
+			local touchingBoosters: { Booster<typeof(Config.TWEEN_CONFIG)> } = {}
 			for _, booster in cache.boosters do
 				if
 					#Workspace:GetPartsInPart(booster.hitbox, overlapParams) > 0
@@ -230,7 +230,7 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 	end
 
 	--> Main functionality
-	local boosterData: Booster = {
+	local boosterData: Booster<typeof(Config.TWEEN_CONFIG)> = {
 		hitbox = booster,
 		configuration = configuration,
 		extraVariables = extraVariables,

--- a/Kit/Repository/Interactables/BouncePad.luau
+++ b/Kit/Repository/Interactables/BouncePad.luau
@@ -29,15 +29,11 @@ local BouncePad = {
 	RunOnStart = false,
 }
 
-local PAD_CONFIG_TEMPLATE
-function BouncePad.Init(utility: _T.Utility)
-	local Config = utility.Config
-	PAD_CONFIG_TEMPLATE = {
-		Power = 100,
-		Cooldown = 0.05,
-		RelativeForce = false,
-	}
-end
+local PAD_CONFIG_TEMPLATE = {
+	Power = 100,
+	Cooldown = 0.05,
+	RelativeForce = false,
+}
 
 function BouncePad.Run(scope: _T.Scope, utility: _T.Utility)
 	--> Setup

--- a/Kit/Repository/Interactables/BouncePad.luau
+++ b/Kit/Repository/Interactables/BouncePad.luau
@@ -75,11 +75,15 @@ function BouncePad.Run(scope: _T.Scope, utility: _T.Utility)
 			cooldownActive = false
 		end)
 
-		if Players:GetPlayerFromCharacter(part.Parent) == player then
-			part = player.Character.PrimaryPart
-
+		if utility.ClientObjects.validatePlayerToucher(part, touchConfiguration.playerHitboxMode) then
+			local charparts = utility.Character.getCharacter()
+			
+			local rootPart = charparts.rootPart
+			if rootPart then
+				part = rootPart
+			end
 			-- fix velocity sometimes being weird
-			local humanoid = utility.Character.getHumanoid()
+			local humanoid = charparts.humanoid
 			if humanoid then
 				humanoid:ChangeState(Enum.HumanoidStateType.Freefall)
 			end

--- a/Kit/Repository/Interactables/Button/init.luau
+++ b/Kit/Repository/Interactables/Button/init.luau
@@ -202,11 +202,11 @@ local function handleButtonCache(rootScope: _T.Scope, utility: _T.Utility): Butt
 	local function handleNewPlatform(platform: BasePart)
 		local this = {} :: typeof(TAGS)
 		cache.ButtonActivatedPlatforms[platform] = this
-		for key in pairs(TAGS) do -- we love broken type inference
+		for key in TAGS do -- we love broken type inference
 			this[key] = platform:HasTag(key)
 		end
 		if not this.IgnoreInitialActivate then
-			task.defer(activatePlatform, platform, false)
+			task.defer(activatePlatform, platform, false, nil)
 		end
 	end
 
@@ -214,7 +214,7 @@ local function handleButtonCache(rootScope: _T.Scope, utility: _T.Utility): Butt
 		if not tagFilter(platform) then
 			continue
 		end
-		handleNewPlatform(platform)
+		handleNewPlatform(platform :: BasePart)
 	end
 	rootScope:add(CollectionService:GetInstanceAddedSignal(PLATFORM_TAG):Connect(function(instance)
 		if not tagFilter(instance) or not instance:IsA("BasePart") then
@@ -372,12 +372,12 @@ function Button.Run(scope: _T.Scope, utility: _T.Utility)
 		cache.Buttons[buttonPart] = nil
 	end)
 
-	local timerLabel = buttonConfig:FindFirstChildWhichIsA("TextLabel")
+	local timerLabel = buttonConfig:FindFirstChildWhichIsA("TextLabel") :: TextLabel?
 
 	local function updatePlatforms(pressed: boolean?)
 		-- don't deactivate if there's a different button of the same color active
 		-- this is to match v5.5 behavior
-		
+
 		if not pressed then
 			for _, otherButton in cache.Buttons do
 				if

--- a/Kit/Repository/Interactables/Button/init.luau
+++ b/Kit/Repository/Interactables/Button/init.luau
@@ -92,21 +92,17 @@ local Button = {
 	Communicator = COMMUNICATOR,
 }
 
-local BUTTON_CONFIG_TEMPLATE
-function Button.Init(utility: _T.Utility)
-	local Config = utility.Config
-	BUTTON_CONFIG_TEMPLATE = {
-		Timer = 0,
-		TimerDecimalPlaces = 1,
-		TimerText = "{T}",
-		PressOffset = CFrame.new(Vector3.yAxis * 0.75),
-		PressedMaterial = Config.Type.Enum(Enum.Material.Neon),
-		HideGUI = false,
+local BUTTON_CONFIG_TEMPLATE = {
+	Timer = 0,
+	TimerDecimalPlaces = 1,
+	TimerText = "{T}",
+	PressOffset = CFrame.new(Vector3.yAxis * 0.75),
+	PressedMaterial = Enum.Material.Neon,
+	HideGUI = false,
 
-		PadMode = false,
-		PadDistance = 5,
-	}
-end
+	PadMode = false,
+	PadDistance = 5,
+}
 
 type ConfigTemplate = typeof(BUTTON_CONFIG_TEMPLATE)
 type Button = _TDefs.Button<ConfigTemplate>

--- a/Kit/Repository/Interactables/DialogSystem/init.luau
+++ b/Kit/Repository/Interactables/DialogSystem/init.luau
@@ -46,6 +46,11 @@ type TextSequence = {
 	TypeSound: Sound?,
 }
 
+-- important variables
+local player = Players.LocalPlayer :: Player
+local playerMouse = player:GetMouse()
+local Typewriter = require((ReplicatedStorage:WaitForChild("DialogModuleInstance") :: any).Value) :: any -- why the hell
+
 function DialogSystem.Run(scope: _T.Scope, utility: _T.Utility)
 	local Config = utility.Config
 	local roundColor = utility.Functions.roundColor
@@ -64,11 +69,6 @@ function DialogSystem.Run(scope: _T.Scope, utility: _T.Utility)
 	if not dialogParts then
 		return
 	end
-
-	-- important variables
-	local player = Players.LocalPlayer
-	local playerMouse = player:GetMouse()
-	local Typewriter = require(ReplicatedStorage:WaitForChild("DialogModuleInstance").Value)
 
 	local dialogUI = player.PlayerGui:WaitForChild("Dialog")
 	local textFrame = dialogUI:WaitForChild("textFrame")

--- a/Kit/Repository/Interactables/JumpLauncher.luau
+++ b/Kit/Repository/Interactables/JumpLauncher.luau
@@ -31,16 +31,12 @@ local JumpLauncher = {
 	RunOnStart = false,
 }
 
-local LAUNCHER_CONFIG_TEMPLATE
-function JumpLauncher.Init(utility: _T.Utility)
-	local Config = utility.Config
-	LAUNCHER_CONFIG_TEMPLATE = {
-		Cooldown = 0.25,
-		Force = 60,
-		SizeReduction = Vector3.one,
-		Transparency = Config.Type.number,
-	}
-end
+local LAUNCHER_CONFIG_TEMPLATE = {
+	Cooldown = 0.25,
+	Force = 60,
+	SizeReduction = Vector3.one,
+	Transparency = Config.Type.number,
+}
 
 local player = Players.LocalPlayer
 local function handleCache(rootScope: _T.Scope, utility: _T.Utility)
@@ -202,7 +198,7 @@ function JumpLauncher.Run(scope: _T.Scope, utility: _T.Utility)
 					utility.Functions.playSoundFromInstance(jumpLauncher, soundsFolder, "Bounce")
 					local targetTransparency = if invisible
 						then 1
-						else configuration.Transparency or originalTransparency
+						else (if not math.isnan(configuration.Transparency) then configuration.Transparency else originalTransparency)
 					jumpLauncher.Transparency = if invisible then 1 else targetTransparency / 4
 					utility.Functions.tween(jumpLauncher, 0.5, { Transparency = targetTransparency })
 					if bounceParticle then

--- a/Kit/Repository/Interactables/JumpLauncher.luau
+++ b/Kit/Repository/Interactables/JumpLauncher.luau
@@ -38,7 +38,7 @@ local LAUNCHER_CONFIG_TEMPLATE = {
 	Transparency = math.nan,
 }
 
-local player = Players.LocalPlayer
+local player = Players.LocalPlayer :: Player
 local function handleCache(rootScope: _T.Scope, utility: _T.Utility)
 	local cache = {
 		playerBuffering = false,
@@ -98,7 +98,7 @@ function JumpLauncher.Run(scope: _T.Scope, utility: _T.Utility)
 	local configuration = Config.GetConfig(scope, launcherConfig, LAUNCHER_CONFIG_TEMPLATE):ObserveChanges()
 	local touchConfiguration =
 		Config.GetConfig(scope, launcherConfig:FindFirstChild("TouchConfiguration"), Config.TOUCH_CONFIG)
-			:ObserveChanges()
+		:ObserveChanges()
 
 	--> Model Setup
 	local soundsFolder = jumpLauncher:FindFirstChild("Sounds")

--- a/Kit/Repository/Interactables/JumpLauncher.luau
+++ b/Kit/Repository/Interactables/JumpLauncher.luau
@@ -35,7 +35,7 @@ local LAUNCHER_CONFIG_TEMPLATE = {
 	Cooldown = 0.25,
 	Force = 60,
 	SizeReduction = Vector3.one,
-	Transparency = Config.Type.number,
+	Transparency = math.nan,
 }
 
 local player = Players.LocalPlayer

--- a/Kit/Repository/Interactables/KeyGroup/TypeDefs.luau
+++ b/Kit/Repository/Interactables/KeyGroup/TypeDefs.luau
@@ -45,7 +45,7 @@ export type Key = {
 		startTimer: number?,
 		collectKey: (self: Key) -> (),
 		returnKey: (self: Key) -> (),
-		viewport: typeof(script.KeyViewport),
+		viewport: typeof(script.Parent.KeyViewport),
 	}?,
 }
 export type KeyDoor = {

--- a/Kit/Repository/Interactables/KeyGroup/init.luau
+++ b/Kit/Repository/Interactables/KeyGroup/init.luau
@@ -42,7 +42,6 @@ local DOOR_DESTROY_METHODS = {
 		tween.Completed:Once(function()
 			part:Destroy()
 			tween:Destroy()
-			tween = nil
 		end)
 	end,
 
@@ -62,7 +61,7 @@ local DOOR_DESTROY_METHODS = {
 		for _, joint in part:GetJoints() do -- BreakJoints is deprecated
 			joint:Destroy()
 		end
-		
+
 		task.delay(10, function()
 			part:Destroy()
 		end)
@@ -130,7 +129,7 @@ local function handleKeyCache(rootScope: _T.Scope, utility: _T.Utility): Cache
 		emitter.Parent = Workspace
 		emitter:PivotTo(self.hitbox:GetPivot())
 
-		local particle = self.hitbox:FindFirstChild("ReplaceEffect")
+		local particle = self.hitbox:FindFirstChild("ReplaceEffect") :: ParticleEmitter
 		if not particle or not particle:IsA("ParticleEmitter") then
 			particle = script.Effect:Clone()
 		end
@@ -177,7 +176,7 @@ local function handleKeyCache(rootScope: _T.Scope, utility: _T.Utility): Cache
 
 	local function keyConstructor(group: KeyGroup, key: Key): Key?
 		if not key.instance or not key.instance.Parent then
-			return
+			return nil
 		end
 
 		local id = generateUID()
@@ -193,6 +192,8 @@ local function handleKeyCache(rootScope: _T.Scope, utility: _T.Utility): Cache
 			collectKey = collectKey,
 			returnKey = returnKey,
 			group = group,
+			targetCFrame = nil,
+			startTimer = nil,
 		}
 		key.__private = cacheData
 
@@ -350,7 +351,7 @@ local function handleKeyCache(rootScope: _T.Scope, utility: _T.Utility): Cache
 	local lastTrailUpdateTime = 0
 
 	local characterInstances = utility.Character.getCharacter()
-	local currentCamera = Workspace.CurrentCamera
+	local currentCamera = Workspace.CurrentCamera :: Camera
 	local formatTimer = utility.ClientObjects.formatTimerText
 	rootScope:add(RunService.Heartbeat:Connect(function(deltaTime: number)
 		debug.profilebegin("KeyGroup > Loop")
@@ -370,7 +371,7 @@ local function handleKeyCache(rootScope: _T.Scope, utility: _T.Utility): Cache
 			(#cache.activeKeys <= 0 and (currentClock - lastTrailUpdateTime) > TRAIL_UPDATE_THRESHOLD)
 			or (
 				not lastTrailUpdatePosition
-				or (currentPosition - lastTrailUpdatePosition).Magnitude > TRAIL_UPDATE_THRESHOLD
+					or (currentPosition - lastTrailUpdatePosition).Magnitude > TRAIL_UPDATE_THRESHOLD
 			)
 		then
 			table.insert(trailList, 1, currentPosition)
@@ -494,7 +495,7 @@ function KeyGroup.Run(scope: _T.Scope, utility: _T.Utility)
 
 				local keyConfig =
 					Config.GetConfig(scope, instance:FindFirstChild("KeyConfiguration"), KEY_CONFIG_TEMPLATE)
-						:ObserveChanges()
+					:ObserveChanges()
 
 				local thisKey = assert(thisGroup:addKey({
 					instance = instance,
@@ -536,7 +537,7 @@ function KeyGroup.Run(scope: _T.Scope, utility: _T.Utility)
 
 				local doorConfig =
 					Config.GetConfig(scope, instance:FindFirstChild("DoorConfiguration"), DOOR_CONFIG_TEMPLATE)
-						:ObserveChanges()
+					:ObserveChanges()
 
 				local thisDoor = assert(thisGroup:addDoor({
 					instance = instance,

--- a/Kit/Repository/Interactables/KeyGroup/init.luau
+++ b/Kit/Repository/Interactables/KeyGroup/init.luau
@@ -78,22 +78,16 @@ local KeyGroup = {
 	RunOnStart = false,
 }
 
-local KEY_CONFIG_TEMPLATE
-local DOOR_CONFIG_TEMPLATE
-
-function KeyGroup.Init(utility: _T.Utility)
-	local Config = utility.Config
-	KEY_CONFIG_TEMPLATE = {
-		SpinSpeed = 5,
-		Timer = 0,
-		TimerDecimalPlaces = 1,
-		ViewportOffset = CFrame.identity,
-		TimerText = "{T}",
-	}
-	DOOR_CONFIG_TEMPLATE = {
-		RequiredKeys = 1,
-	}
-end
+local KEY_CONFIG_TEMPLATE = {
+	SpinSpeed = 5,
+	Timer = 0,
+	TimerDecimalPlaces = 1,
+	ViewportOffset = CFrame.identity,
+	TimerText = "{T}",
+}
+local DOOR_CONFIG_TEMPLATE = {
+	RequiredKeys = 1,
+}
 
 local _TDefs = require(script.TypeDefs)
 type Key = _TDefs.Key

--- a/Kit/Repository/Interactables/Morpher/init.luau
+++ b/Kit/Repository/Interactables/Morpher/init.luau
@@ -31,17 +31,17 @@ local Morpher = {
 	RunOnStart = false,
 }
 
-local BUTTON_CONFIG_TEMPLATE
+local BUTTON_CONFIG_TEMPLATE = {
+	Timer = 0,
+	TimerText = "{T}",
+	TimerDecimalPlaces = 1,
+	CarryObjects = true,
+}
 local TOUCH_CONFIGURATION
 local TWEEN_CONFIGURATION
 function Morpher.Init(utility: _T.Utility)
 	local Config = utility.Config
-	BUTTON_CONFIG_TEMPLATE = {
-		Timer = 0,
-		TimerText = "{T}",
-		TimerDecimalPlaces = 1,
-		CarryObjects = true,
-	}
+	
 	TOUCH_CONFIGURATION = Config.TOUCH_CONFIG
 	TWEEN_CONFIGURATION = Config.TWEEN_CONFIG
 end

--- a/Kit/Repository/Interactables/MusicZoneEditor/init.luau
+++ b/Kit/Repository/Interactables/MusicZoneEditor/init.luau
@@ -39,10 +39,6 @@ local EDITOR_CONFIG_TEMPLATE = {
 	OneTimeUse = false,
 	Cooldown = 1,
 }
-function MusicZoneEditor.Init(utility: _T.Utility)
-	local Config = utility.Config
-	
-end
 
 local SequencerSupport = require(script.SequencerSupport)
 local function handleCache(rootScope: _T.Scope, utility: _T.Utility)

--- a/Kit/Repository/Interactables/MusicZoneEditor/init.luau
+++ b/Kit/Repository/Interactables/MusicZoneEditor/init.luau
@@ -34,14 +34,14 @@ local MusicZoneEditor = {
 	RunOnStart = false,
 }
 
-local EDITOR_CONFIG_TEMPLATE
+local EDITOR_CONFIG_TEMPLATE = {
+	ZoneName = "",
+	OneTimeUse = false,
+	Cooldown = 1,
+}
 function MusicZoneEditor.Init(utility: _T.Utility)
 	local Config = utility.Config
-	EDITOR_CONFIG_TEMPLATE = {
-		ZoneName = "",
-		OneTimeUse = false,
-		Cooldown = 1,
-	}
+	
 end
 
 local SequencerSupport = require(script.SequencerSupport)

--- a/Kit/Repository/Interactables/PropertyChanger/init.luau
+++ b/Kit/Repository/Interactables/PropertyChanger/init.luau
@@ -93,7 +93,7 @@ local function handleCache(rootScope: _T.Scope, utility: _T.Utility): _TDefs.Cac
 	local shared = rootScope.shared
 	local clientObjects = rootScope.clientObjects
 	local characterInstances = utility.Character.getCharacter()
-	local localPlayer = Players.LocalPlayer
+	local localPlayer = Players.LocalPlayer :: Player
 	local function tagFilter(instance: Instance)
 		if BLACKLISTED_CLASSES[instance.ClassName] then
 			return false
@@ -307,7 +307,7 @@ local function handleCache(rootScope: _T.Scope, utility: _T.Utility): _TDefs.Cac
 		IsJumping = function()
 			return utility.JumpButton.IsDown()
 		end,
-		IsKeyDown = function(key: string | Enum.KeyCode)
+		IsKeyDown = function(_, key: string | Enum.KeyCode)
 			return UserInputService:IsKeyDown(key)
 		end,
 		PreferredInput = function()

--- a/Kit/Repository/Interactables/Sequencer/init.luau
+++ b/Kit/Repository/Interactables/Sequencer/init.luau
@@ -132,28 +132,22 @@ local Sequencer = {
 
 	Communicator = COMMUNICATOR,
 }
-local SEQUENCER_CONFIG_TEMPLATE
-local MUSIC_SYNC_CONFIG_TEMPLATE
-local STOPPER_CONFIG_TEMPLATE
-function Sequencer.Init(utility: _T.Utility)
-	local Config = utility.Config
-	SEQUENCER_CONFIG_TEMPLATE = {
-		LoopAmount = 0,
-		LoopDelay = 0,
-		Cooldown = 0,
-		Speed = 1,
-		Visualize = false,
-		RunAtStart = false,
-		HideSequence = false,
-	}
-	MUSIC_SYNC_CONFIG_TEMPLATE = {
-		ZoneName = Config.Type.string,
-		SyncEnabled = false,
-	}
-	STOPPER_CONFIG_TEMPLATE = {
-		BreakLoop = false,
-	}
-end
+local SEQUENCER_CONFIG_TEMPLATE = {
+	LoopAmount = 0,
+	LoopDelay = 0,
+	Cooldown = 0,
+	Speed = 1,
+	Visualize = false,
+	RunAtStart = false,
+	HideSequence = false,
+}
+local MUSIC_SYNC_CONFIG_TEMPLATE = {
+	ZoneName = "",
+	SyncEnabled = false,
+}
+local STOPPER_CONFIG_TEMPLATE = {
+	BreakLoop = false,
+}
 
 local musicManager
 function Sequencer.Run(scope: _T.Scope, utility: _T.Utility)

--- a/Kit/Repository/Interactables/Sequencer/init.luau
+++ b/Kit/Repository/Interactables/Sequencer/init.luau
@@ -204,7 +204,7 @@ function Sequencer.Run(scope: _T.Scope, utility: _T.Utility)
 	local syncConfiguration = Config.GetConfig(scope, musicSyncConfig, MUSIC_SYNC_CONFIG_TEMPLATE):ObserveChanges()
 
 	local syncData
-	if musicSyncConfig and syncConfiguration.SyncEnabled and syncConfiguration.ZoneName then
+	if musicSyncConfig and syncConfiguration.SyncEnabled then
 		local syncPointer = utility.Instance.getPointer(musicSyncConfig:FindFirstChild("Sync"))
 		if syncPointer then
 			syncData = utility.SongTime.BuildSyncCache(require(syncPointer) :: any)

--- a/Kit/Repository/Interactables/Teleporter/init.luau
+++ b/Kit/Repository/Interactables/Teleporter/init.luau
@@ -81,10 +81,10 @@ function Teleporter.Run(scope: _T.Scope, utility: _T.Utility)
 	local configuration = Config.GetConfig(scope, teleporterConfig, TELEPORTER_CONFIG_TEMPLATE):ObserveChanges()
 	local touchConfiguration =
 		Config.GetConfig(scope, teleporterConfig:FindFirstChild("TouchConfiguration"), Config.TOUCH_CONFIG)
-			:ObserveChanges()
+		:ObserveChanges()
 	local tweenConfiguration =
 		Config.GetConfig(scope, teleporterConfig:FindFirstChild("TweenConfiguration"), Config.TWEEN_CONFIG)
-			:ObserveChanges()
+		:ObserveChanges()
 
 	local function getActiveDestinations()
 		return utility.Table.Filter(destinationParts, function(destination)
@@ -94,6 +94,7 @@ function Teleporter.Run(scope: _T.Scope, utility: _T.Utility)
 
 	--> Main Functionality
 	local isTeleporting = false
+	local charparts = utility.Character.getCharacter()
 	local function teleport(teleporter: BasePart, part: BasePart, isPlayer: boolean)
 		local activeDestinations = getActiveDestinations()
 		if isTeleporting or teleporter:GetAttribute("Activated") == false or #activeDestinations <= 0 then
@@ -116,7 +117,7 @@ function Teleporter.Run(scope: _T.Scope, utility: _T.Utility)
 		end
 		if configuration.DisableCollision then
 			if isPlayer then
-				for _, part in localPlayer.Character:GetChildren() do
+				for _, part in charparts.character:GetChildren() do
 					if not part:IsA("BasePart") or savedPartProperties[part] ~= nil then
 						continue
 					end
@@ -138,7 +139,7 @@ function Teleporter.Run(scope: _T.Scope, utility: _T.Utility)
 		local teleporterCFrame = teleporter:GetPivot()
 		local targetCFrame = destinationCFrame * configuration.Offset
 
-		local camera = Workspace.CurrentCamera
+		local camera = Workspace.CurrentCamera :: Camera
 		local targetCameraCFrame
 		if configuration.SeamlessTeleport then
 			targetCFrame = destinationCFrame * teleporterCFrame:ToObjectSpace(part:GetPivot())
@@ -189,7 +190,7 @@ function Teleporter.Run(scope: _T.Scope, utility: _T.Utility)
 			end
 
 			local part: BasePart?
-			local character = localPlayer.Character
+			local character = charparts.character
 			local isPlayer = false
 			if touchingPart:IsDescendantOf(character) and character.PrimaryPart then
 				isPlayer = true
@@ -207,7 +208,7 @@ function Teleporter.Run(scope: _T.Scope, utility: _T.Utility)
 		if touchConfiguration.canFlip then
 			teleporter:AddTag("DoNotFlipPlayer")
 			scope:add(utility.ClientObjects.bindToFlip(teleporter, function()
-				teleport(teleporter, localPlayer.Character.PrimaryPart, true)
+				teleport(teleporter, charparts.primaryPart :: BasePart, true)
 			end))
 		end
 	end
@@ -215,7 +216,7 @@ function Teleporter.Run(scope: _T.Scope, utility: _T.Utility)
 	--> Sequencer Cache Support
 	local cache = utility.Scope.getCached(scope, scope.scriptPath, handleCache)
 	cache[teleporterModel] = function()
-		teleport(teleporterParts[1], localPlayer.Character.PrimaryPart, true)
+		teleport(teleporterParts[1], charparts.primaryPart :: BasePart, true)
 	end
 	scope:add(function()
 		cache[teleporterModel] = nil

--- a/Kit/Repository/Interactables/TripPart/init.luau
+++ b/Kit/Repository/Interactables/TripPart/init.luau
@@ -63,8 +63,9 @@ function TripPart.Run(scope: _T.Scope, utility: _T.Utility)
 
 	--> Main Functionality
 	local tripCooldown = false
+	local charparts = utility.Character.getCharacter()
 	local function trip()
-		local humanoid = player.Character:FindFirstChildWhichIsA("Humanoid")
+		local humanoid = charparts.humanoid
 		if not humanoid then
 			return
 		end

--- a/Kit/Repository/Interactables/Turret/init.luau
+++ b/Kit/Repository/Interactables/Turret/init.luau
@@ -57,7 +57,7 @@ local function handleCache(rootScope: _T.Scope, utility: _T.Utility)
 	return cache
 end
 
-local player = Players.LocalPlayer
+local player = Players.LocalPlayer :: Player
 function Turret.Run(scope: _T.Scope, utility: _T.Utility)
 	local turretConfig = scope.instance
 	if not turretConfig then
@@ -110,9 +110,6 @@ function Turret.Run(scope: _T.Scope, utility: _T.Utility)
 		return
 	end
 
-	--> Variables
-	local player = Players.LocalPlayer
-
 	--> Functions
 	local function isValidHit(bullet: BasePart, hitPart: BasePart): TurretHitData
 		if
@@ -122,7 +119,7 @@ function Turret.Run(scope: _T.Scope, utility: _T.Utility)
 			return HIT_TYPES.INVALID
 		end
 
-		local hitPlayer = Players:GetPlayerFromCharacter(hitPart.Parent)
+		local hitPlayer = utility.ClientObjects.validatePlayerToucher(hitPart) and player
 		if utility.ClientObjects.evaluateToucher(bullet, hitPart, touchConfiguration) then
 			if hitPlayer then
 				return if hitPlayer == player then HIT_TYPES.VALID_PLAYER else HIT_TYPES.INVALID
@@ -139,7 +136,12 @@ function Turret.Run(scope: _T.Scope, utility: _T.Utility)
 
 		local bulletModel = bulletScope:add(bulletTemplate:Clone())
 		local mainPart = bulletModel.PrimaryPart
-			or bulletModel:FindFirstChild("Bullet")
+			or (function()
+				local bullet = bulletModel:FindFirstChild("Bullet")
+				if bullet and bullet:IsA("BasePart") then
+					bulletModel:FindFirstChild("Bullet")
+				end
+			end)()
 			or (function()
 				local baseBullet = script.Bullet:Clone()
 				baseBullet.Parent = bulletModel

--- a/Kit/Repository/Interactables/Vanisher/init.luau
+++ b/Kit/Repository/Interactables/Vanisher/init.luau
@@ -278,7 +278,10 @@ function Vanisher.Run(scope: _T.Scope, utility: _T.Utility)
 		local selectionBox = vanisherPart.selection
 		local defaults = vanisherPart.defaults
 
-		local blinkSound = vanisher:FindFirstChild("BlinkSound") or script.DefaultBlinkSound
+		local blinkSound = vanisher:FindFirstChild("BlinkSound") :: Sound
+		if not blinkSound or not blinkSound:IsA("Sound") then
+			blinkSound = script.DefaultBlinkSound
+		end
 		blinkSound = blinkSound:Clone()
 		blinkSound.Name = "Blinked"
 		blinkSound.Parent = vanisher
@@ -462,7 +465,8 @@ function Vanisher.Run(scope: _T.Scope, utility: _T.Utility)
 	local function getWholeBody()
 		return utility.Character.getHitbox("StaticWholeBody")
 	end
-
+	
+	local charparts = utility.Character.getCharacter()
 	for _, vanisherPart in vanisherParts do
 		local vanisher = vanisherPart.part
 
@@ -471,7 +475,7 @@ function Vanisher.Run(scope: _T.Scope, utility: _T.Utility)
 				return
 			end
 
-			if hitPart:IsDescendantOf(Players.LocalPlayer.Character) then
+			if hitPart:IsDescendantOf(charparts.character) then
 				hitPart = getWholeBody()[1]
 			end
 

--- a/Kit/Repository/Mountables/Attacher/init.luau
+++ b/Kit/Repository/Mountables/Attacher/init.luau
@@ -56,7 +56,7 @@ local ATTACHER_CONFIG_TEMPLATE = {
 
 local function getLimb(character: Instance?, hitPart: BasePart, limb: Enum.Limb): BasePart?
 	if not character or not limb then
-		return
+		return nil
 	end
 	if limb == Enum.Limb.Unknown then
 		return nil
@@ -65,7 +65,7 @@ local function getLimb(character: Instance?, hitPart: BasePart, limb: Enum.Limb)
 	local limbName = LIMB_MAP[limb]
 	local limbPart = character:FindFirstChild(limbName)
 	if not limbPart or not limbPart:IsA("BasePart") then
-		return
+		return nil
 	end
 	return limbPart
 end
@@ -142,7 +142,7 @@ function Attacher.Run(scope: _T.Scope, utility: _T.Utility)
 
 	local touchConfiguration =
 		Config.GetConfig(scope, attacherConfig:FindFirstChild("TouchConfiguration"), Config.TOUCH_CONFIG)
-			:ObserveChanges()
+		:ObserveChanges()
 
 	--> Main Functionality
 	local touchDebounce = {}
@@ -161,7 +161,7 @@ function Attacher.Run(scope: _T.Scope, utility: _T.Utility)
 
 		local attachTo = nil
 		if hitPart:IsDescendantOf(character) then
-            if table.find(utility.Character.getHitbox("WholeBody"), hitPart) then
+			if table.find(utility.Character.getHitbox("WholeBody"), hitPart) then
 				attachTo = getLimb(character, hitPart, configuration.WeldToLimb)
 			end
 		else

--- a/Kit/Repository/Mountables/Attacher/init.luau
+++ b/Kit/Repository/Mountables/Attacher/init.luau
@@ -44,19 +44,15 @@ local BANNED_STATES = {
 	[Enum.HumanoidStateType.RunningNoPhysics] = true,
 }
 
-local ATTACHER_CONFIG_TEMPLATE
-function Attacher.Init(utility: _T.Utility)
-	local Config = utility.Config
-	ATTACHER_CONFIG_TEMPLATE = {
-		AttachUsingAlign = false,
-		Cooldown = 0.5,
-		CleanDelay = 0,
-		DismountState = Config.Type.Enum(Enum.HumanoidStateType.Jumping),
-		DismountStateEnabled = true,
-		Offset = CFrame.new(0, 0, -5),
-		WeldToLimb = Config.Type.Enum(Enum.Limb.Torso),
-	}
-end
+local ATTACHER_CONFIG_TEMPLATE = {
+	AttachUsingAlign = false,
+	Cooldown = 0.5,
+	CleanDelay = 0,
+	DismountState = Enum.HumanoidStateType.Jumping,
+	DismountStateEnabled = true,
+	Offset = CFrame.new(0, 0, -5),
+	WeldToLimb = Enum.Limb.Torso,
+}
 
 local function getLimb(character: Instance?, hitPart: BasePart, limb: Enum.Limb): BasePart?
 	if not character or not limb then

--- a/Kit/Repository/Physics/MovingPlatform.luau
+++ b/Kit/Repository/Physics/MovingPlatform.luau
@@ -53,25 +53,31 @@ function MovingPlatform.Run(scope: _T.Scope, utility: _T.Utility)
 			:ObserveChanges()
 
 	--> Setup Platform
-	local platform = nil
-	for _, v in model:GetChildren() do
-		if not v:IsA("BasePart") or v.Name ~= "Platform" then
-			continue
+	local platforms = model:QueryDescendants("BasePart#Platform")
+	for _, plat in platforms do
+		if plat.Parent ~= model then
+			table.remove(platforms, table.find(platforms,plat))
 		end
-
-		if platform then
-			scope:log({
-				`{model:GetFullName()} has multiple 'Platform' objects. There should only be one.`,
-				type = "error",
-				printType = "warn",
-				traceback = false,
-			})
-
-			return
-		end
-
-		platform = v
 	end
+	if #platforms == 0 then
+		scope:log({
+			`{model:GetFullName()} has no 'Platform' part.`,
+			type = "error",
+			printType = "warn",
+			traceback = false,
+		})
+		return
+	end
+	if #platforms >= 2 then
+		scope:log({
+			`{model:GetFullName()} has multiple 'Platform' objects. There should only be one.`,
+			type = "error",
+			printType = "warn",
+			traceback = false,
+		})
+		return
+	end
+	local platform = platforms[1] :: BasePart
 
 	local platformAttachment = platform:FindFirstChildOfClass("Attachment")
 	local positions = model:FindFirstChild("Positions")

--- a/Kit/Repository/Physics/OneWayPlatform.luau
+++ b/Kit/Repository/Physics/OneWayPlatform.luau
@@ -51,10 +51,6 @@ local PLATFORM_CONFIG_TEMPLATE = {
 	InactiveTransparency = math.nan,
 	ActivateConnectedParts = false,
 }
-function OneWayPlatform.Init(utility: _T.Utility)
-	local Config = utility.Config
-	
-end
 
 local function handleCache(rootScope: _T.Scope, utility: _T.Utility)
 	local cache = {} :: PlatformCache

--- a/Kit/Repository/Physics/OneWayPlatform.luau
+++ b/Kit/Repository/Physics/OneWayPlatform.luau
@@ -44,16 +44,16 @@ local OneWayPlatform = {
 
 local ACTIVE_KEY = "OneWayPlatform_Activated"
 local ACTIVE_CHECK_IGNORES = { [ACTIVE_KEY] = true }
-local PLATFORM_CONFIG_TEMPLATE
+local PLATFORM_CONFIG_TEMPLATE = {
+	SetActivated = true,
+	Offset = CFrame.identity,
+	ActiveTransparency = math.nan,
+	InactiveTransparency = math.nan,
+	ActivateConnectedParts = false,
+}
 function OneWayPlatform.Init(utility: _T.Utility)
 	local Config = utility.Config
-	PLATFORM_CONFIG_TEMPLATE = {
-		SetActivated = true,
-		Offset = CFrame.identity,
-		ActiveTransparency = Config.Type.number,
-		InactiveTransparency = Config.Type.number,
-		ActivateConnectedParts = false,
-	}
+	
 end
 
 local function handleCache(rootScope: _T.Scope, utility: _T.Utility)
@@ -83,8 +83,8 @@ local function handleCache(rootScope: _T.Scope, utility: _T.Utility)
 			local active = data.Active and upVector:Dot(look) > 0
 			local originalTransparency = data.OriginalTransparency
 			local transparency = if active
-				then data.ActiveTransparency or originalTransparency
-				else data.InactiveTransparency or originalTransparency
+				then (if not math.isnan(data.ActiveTransparency) then data.ActiveTransparency else originalTransparency)
+				else (if not math.isnan(data.InactiveTransparency) then data.InactiveTransparency else originalTransparency)
 
 			for _, otherPart in data.Parts do
 				if otherPart.CanCollide ~= active then

--- a/Kit/Repository/Physics/PushingPlatformTrampoline.luau
+++ b/Kit/Repository/Physics/PushingPlatformTrampoline.luau
@@ -45,13 +45,6 @@ function PushingPlatformTrampoline.Run(scope: _T.Scope, utility: _T.Utility)
 		return
 	end
 
-	local anchor = nil
-	local base = nil
-	local prismatic = nil
-	local vectorForce = nil
-	local lowerLimit = nil
-	local upperLimit = nil
-
 	local active = false
 
 	scope:attach(trampoline)
@@ -61,50 +54,48 @@ function PushingPlatformTrampoline.Run(scope: _T.Scope, utility: _T.Utility)
 	local configuration = Config.GetConfig(scope, trampolineConfig, PLATFORM_CONFIG_TEMPLATE):ObserveChanges()
 
 	--> Get objects and check for problems
-	do
-		anchor = trampoline:FindFirstChild("Anchor")
-		if not anchor or not anchor:IsA("BasePart") then
-			scope:log({
-				"PushingPlatformTrampoline is either missing its Anchor part or has it set up incorrectly.",
-				`Path: {trampoline:GetFullName()}`,
-				type = "warn",
-			})
-			return
-		end
-
-		base = trampoline:FindFirstChild("Base")
-		if not base or not base:IsA("BasePart") then
-			scope:log({
-				"PushingPlatformTrampoline is either missing its Base part or has it set up incorrectly.",
-				`Path: {trampoline:GetFullName()}`,
-				type = "warn",
-			})
-			return
-		end
-
-		prismatic = anchor:FindFirstChildOfClass("PrismaticConstraint")
-		if not prismatic then
-			scope:log({
-				"PushingPlatformTrampoline is missing its PrismaticConstraint and cannot function correctly.",
-				`Path: {trampoline:GetFullName()}`,
-				type = "warn",
-			})
-			return
-		end
-
-		vectorForce = base:FindFirstChildOfClass("VectorForce")
-		if not vectorForce then
-			scope:log({
-				"PushingPlatformTrampoline is missing its VectorForce and cannot function correctly.",
-				`Path: {trampoline:GetFullName()}`,
-				type = "warn",
-			})
-			return
-		end
-
-		upperLimit = prismatic.UpperLimit - 0.2
-		lowerLimit = prismatic.LowerLimit + 0.2
+	const anchor = trampoline:FindFirstChild("Anchor")
+	if not anchor or not anchor:IsA("BasePart") then
+		scope:log({
+			"PushingPlatformTrampoline is either missing its Anchor part or has it set up incorrectly.",
+			`Path: {trampoline:GetFullName()}`,
+			type = "warn",
+		})
+		return
 	end
+
+	const base = trampoline:FindFirstChild("Base")
+	if not base or not base:IsA("BasePart") then
+		scope:log({
+			"PushingPlatformTrampoline is either missing its Base part or has it set up incorrectly.",
+			`Path: {trampoline:GetFullName()}`,
+			type = "warn",
+		})
+		return
+	end
+
+	const prismatic = anchor:FindFirstChildOfClass("PrismaticConstraint")
+	if not prismatic then
+		scope:log({
+			"PushingPlatformTrampoline is missing its PrismaticConstraint and cannot function correctly.",
+			`Path: {trampoline:GetFullName()}`,
+			type = "warn",
+		})
+		return
+	end
+
+	const vectorForce = base:FindFirstChildOfClass("VectorForce")
+	if not vectorForce then
+		scope:log({
+			"PushingPlatformTrampoline is missing its VectorForce and cannot function correctly.",
+			`Path: {trampoline:GetFullName()}`,
+			type = "warn",
+		})
+		return
+	end
+
+	local upperLimit = prismatic.UpperLimit - 0.2
+	local lowerLimit = prismatic.LowerLimit + 0.2
 
 	--> Setup beam if possible
 	local indicatorBeam = trampoline:FindFirstChild("TrampolineBeam", true)

--- a/Kit/Repository/Visual/BeatBlock.luau
+++ b/Kit/Repository/Visual/BeatBlock.luau
@@ -103,7 +103,7 @@ function BeatBlock.Run(scope: _T.Scope, utility: _T.Utility)
 	local syncConfiguration = Config.GetConfig(scope, musicSyncConfig, MUSIC_SYNC_CONFIG_TEMPLATE):ObserveChanges()
 
 	local syncData
-	if syncConfiguration.SyncEnabled and syncConfiguration.ZoneName then
+	if syncConfiguration.SyncEnabled then
 		local syncPointer = utility.Instance.getPointer(musicSyncConfig:FindFirstChild("Sync"))
 		if syncPointer then
 			syncData = utility.SongTime.BuildSyncCache(require(syncPointer) :: any)

--- a/Kit/Repository/Visual/BeatBlock.luau
+++ b/Kit/Repository/Visual/BeatBlock.luau
@@ -28,35 +28,30 @@ local BeatBlock = {
 	RunOnStart = false,
 }
 
-local BEATBLOCK_CONFIG_TEMPLATE
-local MUSIC_SYNC_CONFIG_TEMPLATE
-function BeatBlock.Init(utility: _T.Utility)
-	local Config = utility.Config
-	BEATBLOCK_CONFIG_TEMPLATE = {
-		ChangeCanTouch = true,
-		Indicator = true,
-		IndicatorSize = Vector3.new(3, 3, 3),
-		IndicatorScaleMultiplier = 1,
-		MaterialIndicator = Config.Type.Enum(Enum.Material.SmoothPlastic),
+local BEATBLOCK_CONFIG_TEMPLATE = {
+	ChangeCanTouch = true,
+	Indicator = true,
+	IndicatorSize = Vector3.new(3, 3, 3),
+	IndicatorScaleMultiplier = 1,
+	MaterialIndicator = Enum.Material.SmoothPlastic,
 
-		OffCanCollide = false,
-		OffTransparency = 0.5,
-		OffCanTouch = false,
+	OffCanCollide = false,
+	OffTransparency = 0.5,
+	OffCanTouch = false,
 
-		OnCanCollide = true,
-		OnTransparency = 1,
-		OnCanTouch = true,
+	OnCanCollide = true,
+	OnTransparency = 1,
+	OnCanTouch = true,
 
-		Interval = 1,
-		IndicatorInterval = 0.5,
+	Interval = 1,
+	IndicatorInterval = 0.5,
 
-		ToggleChildren = false,
-	}
-	MUSIC_SYNC_CONFIG_TEMPLATE = {
-		ZoneName = Config.Type.string,
-		SyncEnabled = false,
-	}
-end
+	ToggleChildren = false,
+}
+local MUSIC_SYNC_CONFIG_TEMPLATE = {
+	ZoneName = "",
+	SyncEnabled = false,
+}
 
 local REFRESH_RATE = 1 / 60
 

--- a/Kit/Repository/Visual/Emitter/init.luau
+++ b/Kit/Repository/Visual/Emitter/init.luau
@@ -36,15 +36,15 @@ local Emitter = {
 	RunOnStart = false,
 }
 
-local EMITTER_CONFIG_TEMPLATE
+local EMITTER_CONFIG_TEMPLATE = {
+	GlobalSound = true,
+	Uses = 0, -- refreshes when changed
+	Cooldown = 1,
+}
 local EMMISSION_CONFIG_TEMPLATE
 function Emitter.Init(utility: _T.Utility)
 	local Config = utility.Config
-	EMITTER_CONFIG_TEMPLATE = {
-		GlobalSound = true,
-		Uses = math.huge, -- refreshes when changed
-		Cooldown = 1,
-	}
+	
 	EMMISSION_CONFIG_TEMPLATE = {
 		EmitCount = Config.Type.Some(Config.Type.number, Config.Type.NumberRange, Config.Type.none),
 		EmitDelay = 0,

--- a/Kit/Utility/Character.luau
+++ b/Kit/Utility/Character.luau
@@ -28,11 +28,13 @@ local Character = {}
 local Framework = ReplicatedStorage.Framework
 local Managers = Framework.Kit.Managers
 
+local localPlayer = Players.LocalPlayer
+
 Character.HitboxModes =
 	table.freeze({ "StaticWholeBody", "StaticCenter", "StaticArms", "RootPart", "WholeBody", "Center" })
 export type HitboxModes = "StaticWholeBody" | "StaticCenter" | "StaticArms" | "RootPart" | "WholeBody" | "Center" | string
 
-local function _addToListAndFilter(part, list, params: OverlapParams?)
+local function _addToListAndFilter(part: BasePart, list: {BasePart}, params: OverlapParams?)
 	table.insert(list, part)
 	if typeof(params) == "OverlapParams" then
 		params:AddToFilter(part)
@@ -45,15 +47,19 @@ end
 	See [the documentation on hitbox modes](/docs/misc#hitbox-modes) for more information.
 ]=]
 function Character.getHitbox(mode: HitboxModes, params: OverlapParams?): { BasePart }
-	local parts = {}
+	local parts: {BasePart} = {}
 
-	local character = Players.LocalPlayer.Character
+	if not localPlayer then
+		return {}
+	end
+
+	local character = localPlayer.Character
 	if not character then
 		return parts
 	end
 
 	if mode == "RootPart" or mode:find("Static") then
-		local hitbox = character:FindFirstChild("_HITBOX")
+		local hitbox = character:FindFirstChild("_HITBOX") :: typeof(Managers.CharacterManager._HITBOX)?
 		if not hitbox then
 			return parts
 		end
@@ -76,7 +82,7 @@ function Character.getHitbox(mode: HitboxModes, params: OverlapParams?): { BaseP
 
 			if mode == "WholeBody" then
 				_addToListAndFilter(characterPart, parts, params)
-			elseif mode == "Center" and (characterPart.Name ~= "Left Arm" and characterPart.Name ~= "Right Arm") then
+			elseif (mode :: string) == "Center" and (characterPart.Name ~= "Left Arm" and characterPart.Name ~= "Right Arm") then
 				_addToListAndFilter(characterPart, parts, params)
 			end
 		end
@@ -114,7 +120,7 @@ end
 	See [CharacterManager](/api/CharacterManager#GetHumanoid) for more info.
 ]=]
 function Character.getHumanoid(): Humanoid?
-	return CharacterManager:GetHumanoid(Players.LocalPlayer)
+	return CharacterManager:GetHumanoid(localPlayer)
 end
 
 --[=[
@@ -196,9 +202,10 @@ local weldedShoulders: { Motor6D } = {}
 	the carry animation will stop.
 ]=]
 function Character.carryPart(weldState: boolean, weldTo: BasePart, animationDisabled: boolean)
-	local character = Players.LocalPlayer.Character
-	local humanoid = character and character:FindFirstChildOfClass("Humanoid")
-	if not humanoid then
+	local charParts = Character.getCharacter()
+	local character = charParts.character
+	local humanoid = charParts.humanoid
+	if not character or not humanoid then
 		return
 	end
 
@@ -220,6 +227,9 @@ function Character.carryPart(weldState: boolean, weldTo: BasePart, animationDisa
 		rootWelds[weldTo] = rootWeld
 
 		for index, arm in { character:FindFirstChild("Left Arm"), character:FindFirstChild("Right Arm") } do
+			if not arm:IsA("BasePart") then
+				continue
+			end
 			local shoulder = character:FindFirstChild(`{arm.Name:split(" ")[1]} Shoulder`, true)
 			if not shoulder or not shoulder:IsA("Motor6D") then
 				continue
@@ -269,8 +279,7 @@ function Character.carryPart(weldState: boolean, weldTo: BasePart, animationDisa
 	end
 end
 
-local localPlayer = Players.LocalPlayer
-local characterParts = {}
+local characterParts: {character: Model?, primaryPart: BasePart?, humanoid: Humanoid?, rootPart: BasePart?} = {}
 local function getParts(character: Model)
 	task.defer(function()
 		local humanoid = character:WaitForChild("Humanoid")
@@ -283,10 +292,12 @@ local function getParts(character: Model)
 	end)
 end
 
-if Players.CharacterAutoLoads then
-	getParts(localPlayer.Character or localPlayer.CharacterAdded:Wait())
+if localPlayer then
+	if Players.CharacterAutoLoads then
+		getParts(localPlayer.Character or localPlayer.CharacterAdded:Wait())
+	end
+	localPlayer.CharacterAdded:Connect(getParts)
 end
-localPlayer.CharacterAdded:Connect(getParts)
 
 --[=[
     @within Character
@@ -300,6 +311,10 @@ localPlayer.CharacterAdded:Connect(getParts)
     When the character respawns, all of the values will update accordingly.
 ]=]
 function Character.getCharacter()
+	if not localPlayer then
+		return characterParts
+	end
+	
 	getParts(localPlayer.Character or localPlayer.CharacterAdded:Wait())
 	return characterParts
 end

--- a/Kit/Utility/Character.luau
+++ b/Kit/Utility/Character.luau
@@ -28,7 +28,7 @@ local Character = {}
 local Framework = ReplicatedStorage.Framework
 local Managers = Framework.Kit.Managers
 
-local localPlayer = Players.LocalPlayer
+local localPlayer = Players.LocalPlayer :: Player
 
 Character.HitboxModes =
 	table.freeze({ "StaticWholeBody", "StaticCenter", "StaticArms", "RootPart", "WholeBody", "Center" })
@@ -47,11 +47,7 @@ end
 	See [the documentation on hitbox modes](/docs/misc#hitbox-modes) for more information.
 ]=]
 function Character.getHitbox(mode: HitboxModes, params: OverlapParams?): { BasePart }
-	local parts: {BasePart} = {}
-
-	if not localPlayer then
-		return {}
-	end
+	local parts = {}
 
 	local character = localPlayer.Character
 	if not character then
@@ -202,13 +198,16 @@ local weldedShoulders: { Motor6D } = {}
 	the carry animation will stop.
 ]=]
 function Character.carryPart(weldState: boolean, weldTo: BasePart, animationDisabled: boolean)
-	local charParts = Character.getCharacter()
-	local character = charParts.character
-	local humanoid = charParts.humanoid
-	if not character or not humanoid then
+	local character = localPlayer.Character
+	if not character then
 		return
 	end
 
+	local humanoid = character and character:FindFirstChildOfClass("Humanoid")
+	if not humanoid then
+		return
+	end
+	
 	if weldState then
 		local rootPart = humanoid.RootPart
 		if not rootPart or not weldTo then
@@ -226,10 +225,7 @@ function Character.carryPart(weldState: boolean, weldTo: BasePart, animationDisa
 		rootWeld.Part1 = weldTo
 		rootWelds[weldTo] = rootWeld
 
-		for index, arm in { character:FindFirstChild("Left Arm"), character:FindFirstChild("Right Arm") } do
-			if not arm:IsA("BasePart") then
-				continue
-			end
+		for index, arm: BasePart in { character:FindFirstChild("Left Arm"), character:FindFirstChild("Right Arm") } do
 			local shoulder = character:FindFirstChild(`{arm.Name:split(" ")[1]} Shoulder`, true)
 			if not shoulder or not shoulder:IsA("Motor6D") then
 				continue
@@ -279,7 +275,7 @@ function Character.carryPart(weldState: boolean, weldTo: BasePart, animationDisa
 	end
 end
 
-local characterParts: {character: Model?, primaryPart: BasePart?, humanoid: Humanoid?, rootPart: BasePart?} = {}
+local characterParts = {}
 local function getParts(character: Model)
 	task.defer(function()
 		local humanoid = character:WaitForChild("Humanoid")
@@ -292,12 +288,10 @@ local function getParts(character: Model)
 	end)
 end
 
-if localPlayer then
-	if Players.CharacterAutoLoads then
-		getParts(localPlayer.Character or localPlayer.CharacterAdded:Wait())
-	end
-	localPlayer.CharacterAdded:Connect(getParts)
+if Players.CharacterAutoLoads then
+	getParts(localPlayer.Character or localPlayer.CharacterAdded:Wait())
 end
+localPlayer.CharacterAdded:Connect(getParts)
 
 --[=[
     @within Character
@@ -311,10 +305,6 @@ end
     When the character respawns, all of the values will update accordingly.
 ]=]
 function Character.getCharacter()
-	if not localPlayer then
-		return characterParts
-	end
-	
 	getParts(localPlayer.Character or localPlayer.CharacterAdded:Wait())
 	return characterParts
 end

--- a/Kit/Utility/ClientObjects.luau
+++ b/Kit/Utility/ClientObjects.luau
@@ -235,22 +235,30 @@ function ClientObjects.formatTimerText(text: string, decimalPlaces: number, time
 	local seconds = flooredSeconds % 60
 	local milliseconds = math.floor(timeRemaining * 100) % 100
 
-	local playerName = localPlayer.Name
-	local playerDisplayName = localPlayer.DisplayName
-
-	return text:gsub("{T}", displayTime)
-		:gsub("{M}", tostring(minutes))
-		:gsub("{SM}", if tostring(minutes) == "1" then "" else "s")
-		:gsub("{S}", string.format("%02i", seconds))
-		:gsub("{MS}", string.format("%02i", milliseconds))
-		:gsub("{SS}", if displayTime == "1" then "" else "s")
-		:gsub("{pn}", playerName:lower())
-		:gsub("{Pn}", playerName)
-		:gsub("{PN}", playerName:upper())
-		:gsub("{dn}", playerDisplayName:lower())
-		:gsub("{Dn}", playerDisplayName)
-		:gsub("{DN}", playerDisplayName:upper())
-		:gsub("{UID}", localPlayer.UserId)
+	local playerName = "Player"
+	local playerDisplayName = "Player"
+	local uid = math.nan
+	if localPlayer then
+		playerName = localPlayer.Name
+		playerDisplayName = localPlayer.DisplayName
+		uid = localPlayer.UserId
+	end
+	
+	return (string.gsub(text, "{%w+}", {
+		["{T}"] = displayTime,
+		["{M}"] = tostring(minutes),
+		["{SM}"] = if tostring(minutes) == "1" then "" else "s",
+		["{S}"] = string.format("%02i", seconds),
+		["{MS}"] = string.format("%02i", milliseconds),
+		["{SS}"] = if displayTime == "1" then "" else "s",
+		["{pn}"] = playerName:lower(),
+		["{Pn}"] = playerName,
+		["{PN}"] = playerName:upper(),
+		["{dn}"] = playerDisplayName:lower(),
+		["{Dn}"] = playerDisplayName,
+		["{DN}"] = playerDisplayName:upper(),
+		["{UID}"] = tostring(uid),
+	}))
 end
 
 --[=[

--- a/Kit/Utility/Config/Type.luau
+++ b/Kit/Utility/Config/Type.luau
@@ -36,24 +36,7 @@ Type.Some = function(...): any?
 end
 
 Type.Enum = function<T>(enum: T & EnumItem): T
-	return {
-		type = "EnumItem",
-		ignoreType = true,
-		check = function(value: EnumItem): (boolean, string?)
-			local valueType = typeof(value)
-			local check = valueType == "EnumItem" and value.EnumType == enum.EnumType
-			if not check then
-				return check,
-					`Enum.{enum.EnumType} expected, got {if valueType == "EnumItem"
-						then `Enum.{value.EnumType}`
-						else valueType}`
-			end
-			return check
-		end,
-		checkFailedProcessor = function()
-			return enum
-		end,
-	} :: any
+	return enum
 end
 
 Type.integer = (

--- a/Kit/Utility/Config/init.luau
+++ b/Kit/Utility/Config/init.luau
@@ -105,6 +105,8 @@ local function processValue(value: any, default: any): (any, boolean?)
 		return thisValue
 	elseif typeof(value) ~= typeof(default) then
 		return default
+	elseif typeof(value) == "EnumItem" and typeof(default) == "EnumItem" and value.EnumType ~= default.EnumType then
+		return default
 	end
 
 	return value

--- a/Kit/Utility/Functions.luau
+++ b/Kit/Utility/Functions.luau
@@ -39,7 +39,7 @@ local Config = require(script.Parent.Config)
 	```
 ]=]
 function Functions.generateUID(curlyBraces: boolean?): string
-	return HttpService:GenerateGUID(curlyBraces or false):gsub("-", "")
+	return (HttpService:GenerateGUID(curlyBraces or false):gsub("-", ""))
 end
 
 --[=[
@@ -129,7 +129,7 @@ function Functions.playSoundFromInstance(
 		return newSound
 	end
 
-	return
+	return nil
 end
 
 --[=[

--- a/Kit/Utility/SongTime.luau
+++ b/Kit/Utility/SongTime.luau
@@ -90,7 +90,7 @@ function SongTime.BuildSyncCache(data: SyncModule): MethodCache?
 			"No BPM data found in SongTimeConfiguration",
 			type = "warn",
 		})
-		return
+		return nil
 	end
 
 	if not data.BeatsPerMinute[1] or data.BeatsPerMinute[1].beat ~= 0 then
@@ -98,12 +98,12 @@ function SongTime.BuildSyncCache(data: SyncModule): MethodCache?
 			"BPM must be set at beat 0",
 			type = "warn",
 		})
-		return
+		return nil
 	end
 
 	--> Get & sort BPM and Stop events
 	local events = TableUtil.Extend(data.BeatsPerMinute, data.Stops)
-	table.sort(events, function(a, b)
+	table.sort<<BPMChange | Stop>>(events, function(a, b)
 		return a.beat < b.beat
 	end)
 

--- a/Kit/Utility/Table/init.luau
+++ b/Kit/Utility/Table/init.luau
@@ -130,5 +130,4 @@ function Table.FlipValuesIndices<I, V>(item: { [I]: V }): { [V]: I }
 	return new
 end
 
-local merged = Table.Merge(Table, tableUtil) --table.freeze messes this type up
-return table.freeze(merged) :: typeof(merged)
+return Table.Merge(Table, tableUtil)

--- a/Kit/Utility/Table/table-util.luau
+++ b/Kit/Utility/Table/table-util.luau
@@ -427,7 +427,7 @@ end
 	This function works on arrays, but not dictionaries.
 	:::
 ]=]
-local function Extend<T, E>(target: { T }, extension: { E }): { T } & { E }
+local function Extend<T, E>(target: { T }, extension: { E }): { T | E }
 	local tbl = table.clone(target) :: { any }
 	for _, v in extension do
 		table.insert(tbl, v)
@@ -897,7 +897,7 @@ end
 	TableUtil.IsEmpty({abc = 32}) -- false
 	```
 ]=]
-local function IsEmpty(tbl: { [unknown]: unknown }): boolean
+local function IsEmpty<T, U>(tbl: { [T]: U }): boolean
 	return next(tbl) == nil
 end
 


### PR DESCRIPTION
This PR should resolve as many type errors within the New Type Checker as possible without forcing the New Type Checker onto the EToH v6 kit. Since the old type checker is leaving soon, it's probably best to get as many of these issues out of the way before it gets forced.

There will be future pull requests that will come after this one is merged that will resolve the rest of the type errors and will potentially cause a few minor changes to how the v6 kit functions.

A few notes
- None of the current changes proposed are final. This is a draft!
- I wish to try and reduce how much of the code is changed.
  - Example: I wish to use type casts for Players.LocalPlayer instead of using a bunch of if then statements.
- I try to use `""` and `math.nan` as replacements for the `Utility.Config.Type` types. Instances of this include within the MusicZoneEditor and the JumpLauncher.

Explanations for some stuff
- `ScopeConstructor` will not get any type fixes. I hope to make a PR in the future to make it use the new Luau Classes feature, which includes private properties. AKA exactly what scopes need. But it's not out yet 😕
- `BoostPad` will not get any type fixes. See #109
- `DialogSystem` will not get any type fixes. A PR for a `DialogPart` will be made if #109 is accepted.
- `SequencerSupport` modules will not get any type fixes. A PR will be made for them if this passes.