### PR TITLE
Optimizations to boosters

### DIFF
--- a/Kit/Repository/Interactables/Booster/init.luau
+++ b/Kit/Repository/Interactables/Booster/init.luau
@@ -156,7 +156,6 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 		local lastTick = os.clock()
 		local fpsCap = 1 / 60
 		
-		local isTableEmpty = utility.Table.IsEmpty
 		scope.rootScope:add(RunService.Heartbeat:Connect(function(deltaTime: number)
 			--> Cap loop to 60fps
 			local currentTick = os.clock()
@@ -165,7 +164,7 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 			end
 			lastTick = currentTick
 			
-			if isTableEmpty(cache.boosters) then
+			if not cache.boosters[1] then
 				return
 			end
 			

--- a/Kit/Repository/Interactables/Booster/init.luau
+++ b/Kit/Repository/Interactables/Booster/init.luau
@@ -131,17 +131,14 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 	end
 
 	--> Cache system and main loop for zone boosters
-	local overlapParams = OverlapParams.new()
-	overlapParams.FilterType = Enum.RaycastFilterType.Include
-	overlapParams.CollisionGroup = ""
-	CharacterUtil.getHitbox("StaticWholeBody", overlapParams)
-
 	local cache = utility.Scope.getCached(scope, scope.scriptPath, function()
 		local cache: BoosterCache = {
 			activators = {},
 			boosters = {},
 			activeBoosters = {},
 		}
+		
+		local characterHitboxParts = CharacterUtil.getHitbox("StaticWholeBody")
 
 		local lastTick = os.clock()
 		local fpsCap = 1 / 60
@@ -161,10 +158,17 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 			lastTick = currentTick
 
 			--> Get touching parts and determine if any zone boosters are being touched
+			local touchingParts = {}
+			for _, hitboxPart in characterHitboxParts do
+				for _, part in Workspace:GetPartsInPart(hitboxPart) do
+					touchingParts[part] = true
+				end
+			end
+			
 			local touchingBoosters: { Booster } = {}
 			for _, booster in cache.boosters do
 				if
-					#Workspace:GetPartsInPart(booster.hitbox, overlapParams) > 0
+					touchingParts[booster.hitbox]
 					and booster.hitbox:GetAttribute("Activated") ~= false
 				then
 					table.insert(touchingBoosters, booster)
@@ -299,6 +303,13 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 		})
 		return
 	end
+	
+	scope:add(function()
+		local boosterDataSlot = table.find(cache, boosterData)
+		if boosterDataSlot then
+			table.remove(cache, boosterDataSlot)
+		end
+	end)
 end
 
 return Booster

--- a/Kit/Repository/Interactables/Booster/init.luau
+++ b/Kit/Repository/Interactables/Booster/init.luau
@@ -283,10 +283,6 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 		if touchConfiguration.canFlip then
 			scope:add(utility.ClientObjects.bindToFlip(booster, activateBoost))
 		end
-	elseif configuration.Mode == "Zone" then
-		if ClientObjectUtil.isInstanceActive(scope, boosterData.hitbox) then
-			table.insert(cache.boosters, boosterData)
-		end
 	elseif configuration.Mode == "Pad" then
 		local padHitbox = Instance.fromExisting(booster)
 		padHitbox.Name = "Hitbox"
@@ -309,10 +305,7 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 		padHitbox.Anchored = false
 
 		boosterData.hitbox = padHitbox
-		if ClientObjectUtil.isInstanceActive(scope, boosterData.hitbox) then
-			table.insert(cache.boosters, boosterData)
-		end
-	else
+	elseif configuration.Mode ~= "Zone" then
 		scope:log({
 			"Booster has an unknown Mode and cannot function.",
 			`Path: {booster:GetFullName()}`,
@@ -322,6 +315,10 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 	end
 	
 	if configuration.Mode ~= "Default" then
+		if ClientObjectUtil.isInstanceActive(scope, boosterData.hitbox) then
+			table.insert(cache.boosters, boosterData)
+		end
+		
 		ClientObjectUtil.listenInstanceActive(scope, boosterData.hitbox, nil, function(active)
 			if active then
 				if table.find(cache.boosters, boosterData) then

--- a/Kit/Repository/Interactables/Booster/init.luau
+++ b/Kit/Repository/Interactables/Booster/init.luau
@@ -20,6 +20,7 @@ Thank you
 ]]
 
 local HttpService = game:GetService("HttpService")
+local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local RunService = game:GetService("RunService")
 local Workspace = game:GetService("Workspace")
@@ -62,6 +63,7 @@ function Booster.Init(utility: _T.Utility)
 	}
 end
 
+local player = Players.LocalPlayer
 function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 	--> Setup
 	local boosterConfig = scope.instance
@@ -75,18 +77,19 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 	end
 
 	local CharacterUtil = utility.Character
+	local ClientObjectUtil = utility.ClientObjects
 	local Config = utility.Config
 	local configuration = Config.GetConfig(scope, boosterConfig, BOOSTER_CONFIG_TEMPLATE):ObserveChanges()
 	local touchConfiguration =
 		Config.GetConfig(scope, boosterConfig:FindFirstChild("TouchConfiguration"), Config.TOUCH_CONFIG)
-			:ObserveChanges()
+		:ObserveChanges()
 	local startTweenConfiguration =
 		Config.GetConfig(scope, boosterConfig:FindFirstChild("StartTweenConfiguration"), Config.TWEEN_CONFIG)
-			:ObserveChanges()
+		:ObserveChanges()
 	local endTweenConfiguration =
 		Config.GetConfig(scope, boosterConfig:FindFirstChild("EndTweenConfiguration"), Config.TWEEN_CONFIG)
-			:ObserveChanges()
-		
+		:ObserveChanges()
+
 	local extraVariableConfig = boosterConfig:FindFirstChild("ExtraVariables")
 	local extraVariables = if extraVariableConfig
 		then extraVariableConfig:GetAttributes()
@@ -137,27 +140,36 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 			boosters = {},
 			activeBoosters = {},
 		}
-		
+
 		local overlapParams = OverlapParams.new()
 		overlapParams.CollisionGroup = ""
+		overlapParams.ExcludeInstances = {CharacterUtil.getCharacter().character :: Instance}
 		local characterHitboxParts = CharacterUtil.getHitbox("StaticWholeBody")
+		
+		scope:add(player.CharacterAdded:Connect(function(char: Model)
+			char:WaitForChild("_HITBOX")
+			overlapParams.ExcludeInstances = {char :: Instance}
+			characterHitboxParts = CharacterUtil.getHitbox("StaticWholeBody")
+			print(characterHitboxParts)
+		end))
 
 		local lastTick = os.clock()
 		local fpsCap = 1 / 60
-
+		
 		local isTableEmpty = utility.Table.IsEmpty
 		scope.rootScope:add(RunService.Heartbeat:Connect(function(deltaTime: number)
-			debug.profilebegin("Booster -> Update")
-			if isTableEmpty(cache.boosters) then
-				return
-			end
-
 			--> Cap loop to 60fps
 			local currentTick = os.clock()
 			if currentTick - lastTick < fpsCap then
 				return
 			end
 			lastTick = currentTick
+			
+			if isTableEmpty(cache.boosters) then
+				return
+			end
+			
+			debug.profilebegin("Booster -> Update")
 
 			--> Get touching parts and determine if any zone boosters are being touched
 			local touchingParts = {}
@@ -166,12 +178,11 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 					touchingParts[part] = true
 				end
 			end
-			
+
 			local touchingBoosters: { Booster } = {}
 			for _, booster in cache.boosters do
 				if
 					touchingParts[booster.hitbox]
-					and booster.hitbox:GetAttribute("Activated") ~= false
 				then
 					table.insert(touchingBoosters, booster)
 				end
@@ -273,7 +284,9 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 			scope:add(utility.ClientObjects.bindToFlip(booster, activateBoost))
 		end
 	elseif configuration.Mode == "Zone" then
-		table.insert(cache.boosters, boosterData)
+		if ClientObjectUtil.isInstanceActive(scope, boosterData.hitbox) then
+			table.insert(cache.boosters, boosterData)
+		end
 	elseif configuration.Mode == "Pad" then
 		local padHitbox = Instance.fromExisting(booster)
 		padHitbox.Name = "Hitbox"
@@ -296,7 +309,9 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 		padHitbox.Anchored = false
 
 		boosterData.hitbox = padHitbox
-		table.insert(cache.boosters, boosterData)
+		if ClientObjectUtil.isInstanceActive(scope, boosterData.hitbox) then
+			table.insert(cache.boosters, boosterData)
+		end
 	else
 		scope:log({
 			"Booster has an unknown Mode and cannot function.",
@@ -306,10 +321,26 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 		return
 	end
 	
+	if configuration.Mode ~= "Default" then
+		ClientObjectUtil.listenInstanceActive(scope, boosterData.hitbox, nil, function(active)
+			if active then
+				if table.find(cache.boosters, boosterData) then
+					return
+				end
+				table.insert(cache.boosters, boosterData)
+			else
+				local boosterDataSlot = table.find(cache.boosters, boosterData)
+				if boosterDataSlot then
+					table.remove(cache.boosters, boosterDataSlot)
+				end
+			end
+		end)
+	end
+
 	scope:add(function()
-		local boosterDataSlot = table.find(cache, boosterData)
+		local boosterDataSlot = table.find(cache.boosters, boosterData)
 		if boosterDataSlot then
-			table.remove(cache, boosterDataSlot)
+			table.remove(cache.boosters, boosterDataSlot)
 		end
 	end)
 end

--- a/Kit/Repository/Interactables/Booster/init.luau
+++ b/Kit/Repository/Interactables/Booster/init.luau
@@ -138,6 +138,8 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 			activeBoosters = {},
 		}
 		
+		local overlapParams = OverlapParams.new()
+		overlapParams.CollisionGroup = ""
 		local characterHitboxParts = CharacterUtil.getHitbox("StaticWholeBody")
 
 		local lastTick = os.clock()
@@ -160,7 +162,7 @@ function Booster.Run(scope: _T.Scope, utility: _T.Utility)
 			--> Get touching parts and determine if any zone boosters are being touched
 			local touchingParts = {}
 			for _, hitboxPart in characterHitboxParts do
-				for _, part in Workspace:GetPartsInPart(hitboxPart) do
+				for _, part in Workspace:GetPartsInPart(hitboxPart, overlapParams) do
 					touchingParts[part] = true
 				end
 			end


### PR DESCRIPTION
Boosters are now properly removed from the cache when it's scope is cleaned up, and GetPartsInPart is ran on the player hitbox instead of every booster hitbox.